### PR TITLE
[YAPPIOS-185] 회고 작성일 이슈 수정 및 부가요소 리팩토링

### DIFF
--- a/src/main/java/com/yapp/project/aux/content/RetrospectContent.java
+++ b/src/main/java/com/yapp/project/aux/content/RetrospectContent.java
@@ -1,0 +1,11 @@
+package com.yapp.project.aux.content;
+
+public class RetrospectContent {
+    private RetrospectContent() {}
+    public static final String RETROSPECT_RESULT_SET_OK = "회고 수행 여부 설정을 성공하였습니다.";
+    public static final String RETROSPECT_GET_ALL_BY_DAY_OK = "요일 기준 회고 전체 조회를 성공하였습니다.";
+    public static final String RETROSPECT_GET_BY_ID_OK = "회고 단일 조회를 성공하였습니다.";
+    public static final String RETROSPECT_DELETE_BY_OK = "회고 삭제를 성공하였습니다.";
+    public static final String RETROSPECT_CREATE_OK = "회고 작성을 성공하였습니다.";
+    public static final String RETROSPECT_UPDATE_OK = "회고 수정을 성공하였습니다.";
+}

--- a/src/main/java/com/yapp/project/retrospect/domain/Retrospect.java
+++ b/src/main/java/com/yapp/project/retrospect/domain/Retrospect.java
@@ -43,14 +43,14 @@ public class Retrospect {
     private LocalDateTime createdAt;
 
     @Builder
-    public Retrospect(Routine routine, Snapshot image, String content, Result result, Boolean isReport){
+    public Retrospect(Routine routine, Snapshot image, String content, Result result, Boolean isReport, String date){
         this.routine = routine;
         this.image = image;
         this.content = content;
         this.result = result;
         this.isReport = isReport;
         this.createdAt = KST_LOCAL_DATETIME_NOW();
-        this.date = KST_LOCAL_DATE_NOW();
+        this.date = LocalDate.parse(date);
     }
 
     public void updateRetrospect(String content, Snapshot image) {

--- a/src/main/java/com/yapp/project/retrospect/domain/dto/RetrospectDTO.java
+++ b/src/main/java/com/yapp/project/retrospect/domain/dto/RetrospectDTO.java
@@ -24,7 +24,7 @@ public class RetrospectDTO {
     public static class RequestRetrospectResult {
         @ApiModelProperty(value = "루틴ID 보내주세요.", example = "2", required = true)
         private Long routineId;
-        @ApiModelProperty(value = "회고 작성일 보내주세요.", example = "2021-10-13", required = true)
+        @ApiModelProperty(value = "루틴의 수행일 보내주세요.\n만약 11일 루틴인데 12일 작성한다면 11일을 보내주세요", example = "2021-10-13", required = true)
         private String date;
         @ApiModelProperty(value = "수행 결과 보내주세요.", example = "DONE", required = true)
         private Result result;
@@ -52,7 +52,7 @@ public class RetrospectDTO {
         private Long routineId;
         @ApiModelProperty(value = "회고 내용 보내주세요.", example = "알찬 러닝이었다.", required = true)
         private String content;
-        @ApiModelProperty(value = "회고 작성일 보내주세요.", example = "2021-10-13", required = true)
+        @ApiModelProperty(value = "루틴의 수행일 보내주세요.\n만약 11일 루틴인데 12일 작성한다면 11일을 보내주세요", example = "2021-10-13", required = true)
         private String date;
         @ApiModelProperty(value = "이미지 파일 보내주세요.", example = "multipart/form-data형식으로 보내주세요", required = true)
         private MultipartFile image;
@@ -66,7 +66,7 @@ public class RetrospectDTO {
         private Long id;
         @ApiModelProperty(value = "회고 내용", example = "알찬 러닝이었다.")
         private String content;
-        @ApiModelProperty(value = "회고 작성일", example = "2021-10-21")
+        @ApiModelProperty(value = "루틴 수행일", example = "2021-10-21")
         private LocalDate date;
         @ApiModelProperty(value = "이미지 경로", example = "이미지 경로입니다.")
         private String image;

--- a/src/main/java/com/yapp/project/retrospect/service/RetrospectService.java
+++ b/src/main/java/com/yapp/project/retrospect/service/RetrospectService.java
@@ -51,7 +51,7 @@ public class RetrospectService {
         Optional<Retrospect> preRetrospect = retrospectRepository.findByRoutineAndDate(routine,
                 LocalDate.parse(retrospectResult.getDate()));
         Retrospect retrospect = preRetrospect.orElseGet(() ->
-                Retrospect.builder().routine(routine).isReport(false).build());
+                Retrospect.builder().routine(routine).isReport(false).date(retrospectResult.getDate()).build());
         retrospect.updateResult(retrospectResult.getResult());
         Retrospect saveRetrospect = retrospectRepository.save(retrospect);
         return RetrospectDTO.ResponseRetrospectMessage.of(StatusEnum.RETROSPECT_OK , "회고 수행 여부 설정 성공", saveRetrospect);
@@ -87,7 +87,7 @@ public class RetrospectService {
                 LocalDate.parse(requestRetrospect.getDate()));
         Retrospect retrospect = preRetrospect.orElseGet(() ->
                 Retrospect.builder().routine(routine).content(requestRetrospect.getContent())
-                        .isReport(false).result(Result.NOT).build());
+                        .isReport(false).result(Result.NOT).date(requestRetrospect.getDate()).build());
         if(imagePath != null) {
             retrospect.updateRetrospect(requestRetrospect.getContent(), snapshotRepository.save(Snapshot.builder().url(imagePath).build()));
         } else {
@@ -132,8 +132,7 @@ public class RetrospectService {
     private boolean checkDateIsInRoutineDate(Routine routine, LocalDate date) {
         DayOfWeek dayOfWeek = date.getDayOfWeek();
         List<String> dateList = routine.getDays().stream().map(x -> x.getDay().toString()).collect(Collectors.toList());
-        boolean isContains = dateList.contains(dayOfWeek.getDisplayName(TextStyle.SHORT, Locale.US).toUpperCase());
-        return isContains;
+        return dateList.contains(dayOfWeek.getDisplayName(TextStyle.SHORT, Locale.US).toUpperCase());
     }
 
     private boolean checkDateIsBeforeTwoDayFromNow(LocalDate date) {

--- a/src/main/java/com/yapp/project/retrospect/service/RetrospectService.java
+++ b/src/main/java/com/yapp/project/retrospect/service/RetrospectService.java
@@ -29,6 +29,7 @@ import java.util.stream.Collectors;
 
 import static com.yapp.project.aux.common.DateUtil.KST_LOCAL_DATE_NOW;
 import static com.yapp.project.aux.common.SnapShotUtil.saveImages;
+import static com.yapp.project.aux.content.RetrospectContent.*;
 
 
 @Service
@@ -54,20 +55,20 @@ public class RetrospectService {
                 Retrospect.builder().routine(routine).isReport(false).date(retrospectResult.getDate()).build());
         retrospect.updateResult(retrospectResult.getResult());
         Retrospect saveRetrospect = retrospectRepository.save(retrospect);
-        return RetrospectDTO.ResponseRetrospectMessage.of(StatusEnum.RETROSPECT_OK , "회고 수행 여부 설정 성공", saveRetrospect);
+        return RetrospectDTO.ResponseRetrospectMessage.of(StatusEnum.RETROSPECT_OK , RETROSPECT_RESULT_SET_OK, saveRetrospect);
     }
 
     @Transactional(readOnly = true)
     public RetrospectDTO.ResponseRetrospectListMessage getRetrospectList(LocalDate date, Account account) {
         List<Retrospect> retrospectList = retrospectRepository.findAllByDateAndRoutineAccount(date, account);
-        return RetrospectDTO.ResponseRetrospectListMessage.of(StatusEnum.RETROSPECT_OK, "요일 기준 회고 전체 조회 성공", retrospectList);
+        return RetrospectDTO.ResponseRetrospectListMessage.of(StatusEnum.RETROSPECT_OK, RETROSPECT_GET_ALL_BY_DAY_OK, retrospectList);
     }
 
     @Transactional(readOnly = true)
     public RetrospectDTO.ResponseRetrospectMessage getRetrospect(Long retrospectId, Account account) {
         Retrospect retrospect = retrospectRepository.findById(retrospectId).orElseThrow(NotFoundRetrospectException::new);
         routineService.checkIsMine(account, retrospect.getRoutine());
-        return RetrospectDTO.ResponseRetrospectMessage.of(StatusEnum.RETROSPECT_OK, "회고 단일 조회 성공", retrospect);
+        return RetrospectDTO.ResponseRetrospectMessage.of(StatusEnum.RETROSPECT_OK, RETROSPECT_GET_BY_ID_OK, retrospect);
     }
 
     @Transactional
@@ -75,7 +76,7 @@ public class RetrospectService {
         Retrospect retrospect = retrospectRepository.findById(retrospectId).orElseThrow(NotFoundRetrospectException::new);
         routineService.checkIsMine(account, retrospect.getRoutine());
         retrospectRepository.delete(retrospect);
-        return Message.builder().msg("삭제 성공").status(StatusEnum.RETROSPECT_OK).build();
+        return Message.builder().msg(RETROSPECT_DELETE_BY_OK).status(StatusEnum.RETROSPECT_OK).build();
     }
 
     @Transactional
@@ -94,7 +95,7 @@ public class RetrospectService {
             retrospect.updateRetrospect(requestRetrospect.getContent());
         }
         Retrospect saveRetrospect = retrospectRepository.save(retrospect);
-        return RetrospectDTO.ResponseRetrospectMessage.of(StatusEnum.RETROSPECT_OK, "회고 작성 성공", saveRetrospect);
+        return RetrospectDTO.ResponseRetrospectMessage.of(StatusEnum.RETROSPECT_OK, RETROSPECT_CREATE_OK, saveRetrospect);
     }
 
     @Transactional
@@ -112,7 +113,7 @@ public class RetrospectService {
         }
         retrospect.updateRetrospect(updateRetrospect.getContent());
         Retrospect saveRetrospect = retrospectRepository.save(retrospect);
-        return RetrospectDTO.ResponseRetrospectMessage.of(StatusEnum.RETROSPECT_OK,"회고 수정 성공", saveRetrospect);
+        return RetrospectDTO.ResponseRetrospectMessage.of(StatusEnum.RETROSPECT_OK,RETROSPECT_UPDATE_OK, saveRetrospect);
     }
 
     private void checkIsUpdateValidity(Retrospect retrospect) {

--- a/src/main/java/com/yapp/project/routine/domain/RoutineDTO.java
+++ b/src/main/java/com/yapp/project/routine/domain/RoutineDTO.java
@@ -12,6 +12,7 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 import static com.yapp.project.aux.content.RoutineContent.DAY_ROUTINE_RATE_OK;
+import static com.yapp.project.aux.content.RoutineContent.RECOMMENDED_ROUTINE_OK;
 
 public class RoutineDTO {
 
@@ -183,7 +184,7 @@ public class RoutineDTO {
                         .description(description).build();
             }).collect(Collectors.toList());
             return ResponseRecommendedRoutineMessageDto.builder().message(
-                    Message.builder().status(StatusEnum.RECOMMENDED_ROUTINE_OK).msg("추천 루틴 조회를 성공하였습니다.").build()
+                    Message.builder().status(StatusEnum.RECOMMENDED_ROUTINE_OK).msg(RECOMMENDED_ROUTINE_OK).build()
             ).data(data).build();
         }
     }

--- a/src/test/java/com/yapp/project/report/template/WeekReportTemplate.java
+++ b/src/test/java/com/yapp/project/report/template/WeekReportTemplate.java
@@ -134,7 +134,7 @@ public class WeekReportTemplate {
     }
 
     public static Retrospect makeRetrospect(Routine routine, Result result, String date) {
-        Retrospect retrospect = Retrospect.builder().result(result).routine(routine).build();
+        Retrospect retrospect = Retrospect.builder().result(result).routine(routine).date(date).build();
         retrospect.updateTestData(id++, LocalDate.parse(date));
         return retrospect;
     }

--- a/src/test/java/com/yapp/project/retrospect/RetrospectServiceTest.java
+++ b/src/test/java/com/yapp/project/retrospect/RetrospectServiceTest.java
@@ -62,9 +62,9 @@ class RetrospectServiceTest {
             Routine fakeRoutine = Routine.builder().account(account).newRoutine(newRoutine).id(1L).build();
             List<RoutineDay> newDays = days.stream().map(day -> RoutineDay.builder().day(day).sequence(0L).routine(fakeRoutine).build()).collect(Collectors.toList());
             fakeRoutine.addDays(newDays);
-            Retrospect fakeRetrospect = Retrospect.builder().routine(fakeRoutine).isReport(false).result(Result.NOT).build();
+            Retrospect fakeRetrospect = Retrospect.builder().routine(fakeRoutine).isReport(false).result(Result.NOT).date("2021-10-12").build();
             Snapshot fakeSnapShot = Snapshot.builder().url("테스트 경로").build();
-            Retrospect fakeRetrospectSnapShot = Retrospect.builder().routine(fakeRoutine).isReport(false).result(Result.NOT).build();
+            Retrospect fakeRetrospectSnapShot = Retrospect.builder().routine(fakeRoutine).isReport(false).result(Result.NOT).date("2021-10-12").build();
             fakeRetrospectSnapShot.updateRetrospect("테스트 회고 내용", fakeSnapShot);
             RetrospectDTO.RequestRetrospect fakeRequestRetrospect =
                     RetrospectDTO.RequestRetrospect.builder().routineId(1L).date("2021-10-12").content("테스트 회고 내용").build();
@@ -99,11 +99,11 @@ class RetrospectServiceTest {
         days.add(Week.TUE);
         RoutineDTO.RequestRoutineDto newRoutine = new RoutineDTO.RequestRoutineDto("타이틀", "목포", days, "07:35", "생활");
         Routine fakeRoutine = Routine.builder().account(account).newRoutine(newRoutine).id(1L).build();
-        Retrospect fakeRetrospect = Retrospect.builder().routine(fakeRoutine).isReport(false).result(Result.NOT).build();
+        Retrospect fakeRetrospect = Retrospect.builder().routine(fakeRoutine).isReport(false).result(Result.NOT).date("2021-11-29").build();
         fakeRetrospect.updateRetrospect("테스트 회고 내용");
         RetrospectDTO.RequestUpdateRetrospect fakeUpdateRetrospect = RetrospectDTO.RequestUpdateRetrospect.builder().retrospectId(1L).content("테스트 회고 수정").build();
 
-        Retrospect fakeRetrospect2 = Retrospect.builder().routine(fakeRoutine).isReport(false).result(Result.NOT).build();
+        Retrospect fakeRetrospect2 = Retrospect.builder().routine(fakeRoutine).isReport(false).result(Result.NOT).date("2021-11-29").build();
         fakeRetrospect2.updateRetrospect("테스트 회고 수정");
 
         // mocking
@@ -124,9 +124,7 @@ class RetrospectServiceTest {
         RetrospectDTO.RequestUpdateRetrospect fakeUpdateRetrospect = RetrospectDTO.RequestUpdateRetrospect.builder().retrospectId(2L).content("테스트 회고 수정").build();
 
         // when then
-        assertThrows(NotFoundRetrospectException.class, () -> {
-            retrospectService.updateRetrospect(fakeUpdateRetrospect, account);
-        });
+        assertThrows(NotFoundRetrospectException.class, () -> retrospectService.updateRetrospect(fakeUpdateRetrospect, account));
     }
 
     @Test
@@ -141,7 +139,7 @@ class RetrospectServiceTest {
             Routine fakeRoutine = Routine.builder().account(account).newRoutine(newRoutine).id(1L).build();
             List<RoutineDay> newDays = days.stream().map(day -> RoutineDay.builder().day(day).sequence(0L).routine(fakeRoutine).build()).collect(Collectors.toList());
             fakeRoutine.addDays(newDays);
-            Retrospect fakeRetrospect = Retrospect.builder().routine(fakeRoutine).isReport(false).result(Result.NOT).build();
+            Retrospect fakeRetrospect = Retrospect.builder().routine(fakeRoutine).isReport(false).result(Result.NOT).date("2021-10-12").build();
             fakeRetrospect.updateRetrospect("테스트 회고 내용");
             RetrospectDTO.RequestRetrospectResult fakeResult =
                     RetrospectDTO.RequestRetrospectResult.builder().routineId(1L).date("2021-10-12").result(Result.DONE).build();
@@ -168,7 +166,7 @@ class RetrospectServiceTest {
 
         RoutineDTO.RequestRoutineDto newRoutine = new RoutineDTO.RequestRoutineDto("타이틀", "목포", days, "07:35", "생활");
         Routine fakeRoutine = Routine.builder().account(account).newRoutine(newRoutine).id(1L).build();
-        Retrospect fakeRetrospect = Retrospect.builder().routine(fakeRoutine).isReport(false).result(Result.NOT).build();
+        Retrospect fakeRetrospect = Retrospect.builder().routine(fakeRoutine).isReport(false).result(Result.NOT).date("2021-10-12").build();
         fakeRetrospect.updateRetrospect("테스트 회고 내용");
         RetrospectDTO.RequestRetrospectResult fakeResult =
                 RetrospectDTO.RequestRetrospectResult.builder().routineId(1L).date("2021-10-12").result(Result.DONE).build();
@@ -177,8 +175,6 @@ class RetrospectServiceTest {
         given(routineService.findIsExistByIdAndIsNotDelete(any())).willReturn(fakeRoutine);
 
         // when then
-        assertThrows(BadRequestRetrospectException.class, () -> {
-            retrospectService.setRetrospectResult(fakeResult, account);
-        });
+        assertThrows(BadRequestRetrospectException.class, () -> retrospectService.setRetrospectResult(fakeResult, account));
     }
 }

--- a/src/test/java/com/yapp/project/routine/RoutineTemplate.java
+++ b/src/test/java/com/yapp/project/routine/RoutineTemplate.java
@@ -45,7 +45,7 @@ public class RoutineTemplate {
 
     public static List<Retrospect> makeCoffeeRetrospectList(Routine coffeeRoutine) {
         List<Retrospect> retrospectList = new ArrayList<>();
-        Retrospect sunDay = Retrospect.builder().content("").routine(coffeeRoutine).result(Result.DONE).build();
+        Retrospect sunDay = Retrospect.builder().content("").routine(coffeeRoutine).result(Result.DONE).date("2021-10-24").build();
         sunDay.updateTestData(retrospectId++, LocalDate.parse("2021-10-24"));
         retrospectList.add(sunDay);
         return retrospectList;
@@ -65,7 +65,7 @@ public class RoutineTemplate {
 
     public static List<Retrospect> makeReadingRetrospectList(Routine readingRoutine) {
         List<Retrospect> retrospectList = new ArrayList<>();
-        Retrospect friDay = Retrospect.builder().content("").routine(readingRoutine).result(Result.DONE).build();
+        Retrospect friDay = Retrospect.builder().content("").routine(readingRoutine).result(Result.DONE).date("2021-10-22").build();
         friDay.updateTestData(retrospectId++, LocalDate.parse("2021-10-22"));
         retrospectList.add(friDay);
         return retrospectList;
@@ -85,9 +85,9 @@ public class RoutineTemplate {
 
     public static List<Retrospect> makeRunningRetrospectList(Routine runningRoutine) {
         List<Retrospect> retrospectList = new ArrayList<>();
-        Retrospect wedDay = Retrospect.builder().content("").routine(runningRoutine).result(Result.DONE).build();
+        Retrospect wedDay = Retrospect.builder().content("").routine(runningRoutine).result(Result.DONE).date("2021-10-20").build();
         wedDay.updateTestData(retrospectId++, LocalDate.parse("2021-10-20"));
-        Retrospect friDay = Retrospect.builder().content("").routine(runningRoutine).result(Result.TRY).build();
+        Retrospect friDay = Retrospect.builder().content("").routine(runningRoutine).result(Result.TRY).date("2021-10-21").build();
         friDay.updateTestData(retrospectId++, LocalDate.parse("2021-10-21"));
         retrospectList.add(wedDay); retrospectList.add(friDay);
         return retrospectList;
@@ -108,11 +108,11 @@ public class RoutineTemplate {
 
     public static List<Retrospect> makeWaterRetrospectList(Routine waterRoutine) {
         List<Retrospect> retrospectList = new ArrayList<>();
-        Retrospect tueDay = Retrospect.builder().content("").routine(waterRoutine).result(Result.DONE).build();
+        Retrospect tueDay = Retrospect.builder().content("").routine(waterRoutine).result(Result.DONE).date("2021-10-19").build();
         tueDay.updateTestData(retrospectId++, LocalDate.parse("2021-10-19"));
-        Retrospect thuDay = Retrospect.builder().content("").routine(waterRoutine).result(Result.TRY).build();
+        Retrospect thuDay = Retrospect.builder().content("").routine(waterRoutine).result(Result.TRY).date("2021-10-21").build();
         thuDay.updateTestData(retrospectId++, LocalDate.parse("2021-10-21"));
-        Retrospect satDay = Retrospect.builder().content("").routine(waterRoutine).result(Result.DONE).build();
+        Retrospect satDay = Retrospect.builder().content("").routine(waterRoutine).result(Result.DONE).date("2021-10-23").build();
         satDay.updateTestData(retrospectId++, LocalDate.parse("2021-10-23"));
         retrospectList.add(tueDay); retrospectList.add(thuDay); retrospectList.add(satDay);
         return retrospectList;


### PR DESCRIPTION
회고 작성일 이슈 수정 및 부가요소 리팩토링
- 회고 작성일은 작성 당일이 아닌 루틴 수행 요일로 설정하도록 수정(생성일은 작성일로 생성된다)예로 11일 수행하는 루틴 회고를 12일에 작성해도 date는 11일로, createAt은 12일로 생성된다.
- 회고 및 루틴 일부 문자 상수 처리
- Swagger 설명 수정
