### PR TITLE
[YAPPIOS-187] 통합테스트시 빌더 부분에 id제거

### DIFF
--- a/src/main/java/com/yapp/project/aux/test/account/AccountTemplate.java
+++ b/src/main/java/com/yapp/project/aux/test/account/AccountTemplate.java
@@ -36,6 +36,10 @@ public class AccountTemplate {
         return makeTestAccount(USERNAME,EMAIL,Authority.ROLE_USER, SOCIAL_TYPE);
     }
 
+    public static Account makeTestAccountForIntegration(){
+        return makeTestAccountForIntegration(USERNAME,EMAIL,Authority.ROLE_USER, SOCIAL_TYPE);
+    }
+
     public static Account makeTestAccount2(){
         return makeTestAccount(ANOTHER_USERNAME,ANOTHER_EMAIL,Authority.ROLE_USER, SOCIAL_TYPE);
     }
@@ -52,8 +56,20 @@ public class AccountTemplate {
         return makeTestAccount(username,email,Authority.ROLE_USER, SOCIAL_TYPE);
     }
 
+    public static Account makeTestAccountForIntegration(String username, String email){
+        return makeTestAccountForIntegration(username,email,Authority.ROLE_USER, SOCIAL_TYPE);
+    }
+
     public static Account makeTestAccount(String username, String email, Authority authority, SocialType socialType){
         Account account = Account.builder().id(id++).nickname(username).password(bCryptPasswordEncoder.encode(PASSWORD))
+                .email(email).createdAt(KST_LOCAL_DATETIME_NOW()).lastLogin(KST_LOCAL_DATETIME_NOW())
+                .authority(authority).socialType(socialType).build();
+        account.clickAlarmToggle();
+        return account;
+    }
+
+    public static Account makeTestAccountForIntegration(String username, String email, Authority authority, SocialType socialType){
+        Account account = Account.builder().nickname(username).password(bCryptPasswordEncoder.encode(PASSWORD))
                 .email(email).createdAt(KST_LOCAL_DATETIME_NOW()).lastLogin(KST_LOCAL_DATETIME_NOW())
                 .authority(authority).socialType(socialType).build();
         account.clickAlarmToggle();

--- a/src/main/java/com/yapp/project/aux/test/mission/MissionTemplate.java
+++ b/src/main/java/com/yapp/project/aux/test/mission/MissionTemplate.java
@@ -39,6 +39,20 @@ public class MissionTemplate {
         return mission;
     }
 
+    public static Mission makeMissionForIntegration(Account account, Organization organization,
+                                      LocalDate startDate, LocalDate finishDate){
+        Mission mission = Mission.builder().
+                account(account).organization(organization)
+                .startDate(startDate).finishDate(finishDate)
+                .isAlarm(true).startTime(LocalTime.of(6,0)).build();
+        mission.defaultSetting();
+        return mission;
+    }
+
+    public static Mission makeMissionForIntegration(Account account, Organization organization){
+        return makeMissionForIntegration(account,organization,START_DATE,FINISH_DATE);
+    }
+
     public static Mission makeMission(Account account, Organization organization){
         return makeMission(account,organization,START_DATE,FINISH_DATE);
     }
@@ -49,6 +63,10 @@ public class MissionTemplate {
 
     public static MissionDto.MissionRequest makeMissionRequest(String startDate, String finishDate){
         return MissionDto.MissionRequest.builder().id(missionId++).startDate(startDate).finishDate(finishDate).weeks(WEEKS).startTime("06:00").build();
+    }
+
+    public static MissionDto.MissionRequest makeMissionRequestForIntegration(String startDate, String finishDate){
+        return MissionDto.MissionRequest.builder().startDate(startDate).finishDate(finishDate).weeks(WEEKS).startTime("06:00").build();
     }
 
 }

--- a/src/main/java/com/yapp/project/aux/test/organization/OrganizationTemplate.java
+++ b/src/main/java/com/yapp/project/aux/test/organization/OrganizationTemplate.java
@@ -35,4 +35,18 @@ public class OrganizationTemplate {
         return organization;
     }
 
+    public static Organization makeTestOrganizationForIntegration(){
+        return makeTestOrganizationForIntegration(TITLE,CATEGORY);
+    }
+
+    public static Organization makeTestOrganizationForIntegration(String title){
+        return makeTestOrganizationForIntegration(title,CATEGORY);
+    }
+
+    public static Organization makeTestOrganizationForIntegration(String title, String category){
+        Organization organization = Organization.builder().title(title).category(category).clause(CLAUSE).rate(86).build();
+        organization.defaultSetting();
+        return organization;
+    }
+
 }

--- a/src/test/java/com/yapp/project/account/controller/AccountControllerTest.java
+++ b/src/test/java/com/yapp/project/account/controller/AccountControllerTest.java
@@ -27,7 +27,7 @@ class AccountControllerTest {
 
     @Test
     void getMyAccountInfo() {
-        Account account = AccountTemplate.makeTestAccount();
+        Account account = AccountTemplate.makeTestAccountForIntegration();
         given(accountService.getUserInfo()).willReturn(AccountDto.UserResponse.of(account));
         AccountDto.UserResponseMessage response = accountController.getMyAccountInfo();
         assertThat(response).isNotNull();

--- a/src/test/java/com/yapp/project/account/controller/AuthControllerTest.java
+++ b/src/test/java/com/yapp/project/account/controller/AuthControllerTest.java
@@ -58,7 +58,7 @@ class AuthControllerTest {
     @Test
     @Transactional
     void test_회원가입_실패(){
-        Account account = AccountTemplate.makeTestAccount();
+        Account account = AccountTemplate.makeTestAccountForIntegration();
         accountRepository.save(account);
         AccountDto.UserRequest accountRequestDto = AccountTemplate.makeAccountRequestDto();
         assertThatThrownBy(() ->authController.signup(accountRequestDto)).isInstanceOf(EmailDuplicateException.class)
@@ -68,7 +68,7 @@ class AuthControllerTest {
     @Test
     @Transactional
     void test_로그인_성공() {
-        Account account = AccountTemplate.makeTestAccount();
+        Account account = AccountTemplate.makeTestAccountForIntegration();
         accountRepository.save(account);
         AccountDto.UserRequest accountRequestDto = AccountTemplate.makeAccountRequestDto();
         ResponseEntity<SocialDto.TokenMessage> response = authController.login(accountRequestDto.toLoginRequest());
@@ -79,7 +79,7 @@ class AuthControllerTest {
     @Test
     @Transactional
     void test_로그인_실페() {
-        Account account = AccountTemplate.makeTestAccount("meaning","meaning@example.com");
+        Account account = AccountTemplate.makeTestAccountForIntegration("meaning","meaning@example.com");
         accountRepository.save(account);
         AccountDto.UserRequest accountRequestDto = AccountTemplate.makeAccountRequestDto();
         assertThatThrownBy(() -> authController.login(accountRequestDto.toLoginRequest())).isInstanceOf(NotFoundUserInformationException.class)
@@ -89,7 +89,7 @@ class AuthControllerTest {
     @Test
     @Transactional
     void test_로그아웃_성공() {
-        Account account = AccountTemplate.makeTestAccount();
+        Account account = AccountTemplate.makeTestAccountForIntegration();
         accountRepository.save(account);
         ResponseEntity<Message> response = authController.logout();
         assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
@@ -98,7 +98,7 @@ class AuthControllerTest {
     @Test
     @Transactional
     void test_로그아웃_실패() {
-        Account account = AccountTemplate.makeTestAccount("meaning","meaning@example.com");
+        Account account = AccountTemplate.makeTestAccountForIntegration("meaning","meaning@example.com");
         accountRepository.save(account);
         assertThatThrownBy(() -> authController.logout()).isInstanceOf(NotFoundUserInformationException.class)
                 .hasMessage(AccountContent.NOT_FOUND_USER_INFORMATION);
@@ -107,7 +107,7 @@ class AuthControllerTest {
     @Test
     @Transactional
     void test_재발급_성공() {
-        Account account = AccountTemplate.makeTestAccount();
+        Account account = AccountTemplate.makeTestAccountForIntegration();
         accountRepository.save(account);
 
         AccountDto.UserRequest accountRequestDto = AccountTemplate.makeAccountRequestDto();
@@ -132,7 +132,7 @@ class AuthControllerTest {
     @Test
     @Transactional
     void test_재발급_토큰_정보_불일치로_인한_실패() {
-        Account account = AccountTemplate.makeTestAccount();
+        Account account = AccountTemplate.makeTestAccountForIntegration();
         accountRepository.save(account);
 
         TokenRequestDto tokenRequestDto = new TokenRequestDto("");
@@ -144,7 +144,7 @@ class AuthControllerTest {
     @Test
     @Transactional
     void test_재발급_토큰_레디스에_토큰_저장이_안되어_있을_때() {
-        Account account = AccountTemplate.makeTestAccount();
+        Account account = AccountTemplate.makeTestAccountForIntegration();
         accountRepository.save(account);
 
         AccountDto.UserRequest accountRequestDto = AccountTemplate.makeAccountRequestDto();
@@ -162,7 +162,7 @@ class AuthControllerTest {
     @Test
     @Transactional
     void test_재발급_요청된_RefreshToken과_Redis에_저장된_RefreshToken이_일치하지_않을_때() {
-        Account account = AccountTemplate.makeTestAccount();
+        Account account = AccountTemplate.makeTestAccountForIntegration();
         accountRepository.save(account);
 
         AccountDto.UserRequest accountRequestDto = AccountTemplate.makeAccountRequestDto();

--- a/src/test/java/com/yapp/project/account/service/AccountServiceTest.java
+++ b/src/test/java/com/yapp/project/account/service/AccountServiceTest.java
@@ -56,7 +56,7 @@ class AccountServiceTest {
     @Test
     @Transactional
     void test_알람토글_변경() {
-        Account account = accountRepository.save(AccountTemplate.makeTestAccount());
+        Account account = accountRepository.save(AccountTemplate.makeTestAccountForIntegration());
         assertThat(account.getIsAlarm()).isFalse();
         accountService.clickAlarmToggle(account);
         assertThat(account.getIsAlarm()).isTrue();
@@ -66,7 +66,7 @@ class AccountServiceTest {
     @Test
     @Transactional
     void getUserInfo() {
-        accountRepository.save(AccountTemplate.makeTestAccount());
+        accountRepository.save(AccountTemplate.makeTestAccountForIntegration());
         AccountDto.UserResponse accountUserResponseDto = accountService.getUserInfo();
         assertThat(accountUserResponseDto.getEmail()).isEqualTo(AccountTemplate.EMAIL);
     }
@@ -74,7 +74,7 @@ class AccountServiceTest {
     @Test
     @Transactional
     void test_비밀번호_재설정(){
-        Account account = accountRepository.save(AccountTemplate.makeTestAccount());
+        Account account = accountRepository.save(AccountTemplate.makeTestAccountForIntegration());
         String prevPassword = account.getPassword();
         AccountDto.ProfilePasswordRequest request = new AccountDto.ProfilePasswordRequest("resetTes23!");
         accountService.resetMyAccountPassword(request, account);
@@ -86,7 +86,7 @@ class AccountServiceTest {
     @Test
     @Transactional
     void test_유저_삭제() {
-        Account account = accountRepository.save(AccountTemplate.makeTestAccount());
+        Account account = accountRepository.save(AccountTemplate.makeTestAccountForIntegration());
         String email = account.getEmail();
         accountService.removeAccount(account);
         Account dbAccount = accountRepository.findByEmail(email).orElse(null);
@@ -100,7 +100,7 @@ class AccountServiceTest {
             dateUtil.when(DateUtil::KST_LOCAL_DATETIME_NOW).thenReturn(LocalDateTime.of(2021,11,9,6,30));
             dateUtil.when(DateUtil::KST_LOCAL_DATE_NOW).thenReturn(LocalDate.of(2021,11,9));
             dateUtil.when(DateUtil::MID_NIGHT).thenReturn(LocalDateTime.of(2021,11,9,0,0)); // 화요일
-            Account account = accountRepository.save(AccountTemplate.makeTestAccount());
+            Account account = accountRepository.save(AccountTemplate.makeTestAccountForIntegration());
             Organization organization = organizationRepository.save(OrganizationTemplate.makeTestOrganization());
             Mission mission = missionRepository.save(MissionTemplate.makeMission(account,organization));
             Capture capture =  captureRepository.save(CaptureTemplate.makeCapture(mission));

--- a/src/test/java/com/yapp/project/account/service/AuthServiceTest.java
+++ b/src/test/java/com/yapp/project/account/service/AuthServiceTest.java
@@ -118,7 +118,7 @@ class AuthServiceTest {
     @Transactional
     void signupFail() {
         //given
-        Account account = AccountTemplate.makeTestAccount();
+        Account account = AccountTemplate.makeTestAccountForIntegration();
         AccountDto.UserRequest accountRequestDto = AccountTemplate.makeAccountRequestDto();
         //when
         accountRepository.save(account);
@@ -131,7 +131,7 @@ class AuthServiceTest {
     @Transactional
     void loginSuccess() {
         //given
-        Account account = AccountTemplate.makeTestAccount();
+        Account account = AccountTemplate.makeTestAccountForIntegration();
         accountRepository.save(account);
         AccountDto.UserRequest accountRequestDto = AccountTemplate.makeAccountRequestDto();
         //when
@@ -183,7 +183,7 @@ class AuthServiceTest {
     @Transactional
     void test_인증번호_서버에서_보냈을_때(){
         //given
-        Account account = AccountTemplate.makeTestAccount();
+        Account account = AccountTemplate.makeTestAccountForIntegration();
         accountRepository.save(account);
         String email = account.getEmail();
         AccountDto.EmailRequest request = new AccountDto.EmailRequest(email);
@@ -198,7 +198,7 @@ class AuthServiceTest {
     @Transactional
     void test_인증번호_인증_성공했을_때(){
         //given
-        Account account = AccountTemplate.makeTestAccount();
+        Account account = AccountTemplate.makeTestAccountForIntegration();
         accountRepository.save(account);
         String email = account.getEmail();
         AccountDto.EmailRequest emailRequest = new AccountDto.EmailRequest(email);
@@ -218,7 +218,7 @@ class AuthServiceTest {
     @Transactional
     void test_비밀번호_재설정_성공했을_때(){
         //given
-        Account account = AccountTemplate.makeTestAccount();
+        Account account = AccountTemplate.makeTestAccountForIntegration();
         accountRepository.save(account);
         String email = account.getEmail();
         AccountDto.ResetPasswordRequest request = new AccountDto.ResetPasswordRequest(email, "NewPwd12$@#");

--- a/src/test/java/com/yapp/project/batch/job/GroupConfigTest.java
+++ b/src/test/java/com/yapp/project/batch/job/GroupConfigTest.java
@@ -46,9 +46,9 @@ class GroupConfigTest {
     @Test
     void test_그룹관련_배치_테스트() throws Exception {
         //given
-        Account account = accountRepository.save(AccountTemplate.makeTestAccount2());
-        Account account2 = accountRepository.save(AccountTemplate.makeTestAccount("user2", "hello@example.com"));
-        Organization organization = organizationRepository.save(OrganizationTemplate.makeTestOrganization());
+        Account account = accountRepository.save(AccountTemplate.makeTestAccountForIntegration());
+        Account account2 = accountRepository.save(AccountTemplate.makeTestAccountForIntegration("user2", "hello@example.com"));
+        Organization organization = organizationRepository.save(OrganizationTemplate.makeTestOrganizationForIntegration());
         LocalDate yesterday = DateUtil.KST_LOCAL_DATE_YESTERDAY();
         Mission mission = MissionTemplate.makeMission(account,organization, yesterday.minusDays(5), yesterday.plusDays(2));
         Mission mission2 = MissionTemplate.makeMission(account2,organization,yesterday.minusDays(14), yesterday);

--- a/src/test/java/com/yapp/project/retrospect/RetrospectServiceTest.java
+++ b/src/test/java/com/yapp/project/retrospect/RetrospectServiceTest.java
@@ -92,29 +92,32 @@ class RetrospectServiceTest {
 
     @Test
     void testUpdateNonImageSuccess() throws IOException {
-        // given
-        Account account = AccountTemplate.makeTestAccount();
-        List<Week> days = new ArrayList<>();
-        days.add(Week.MON);
-        days.add(Week.TUE);
-        RoutineDTO.RequestRoutineDto newRoutine = new RoutineDTO.RequestRoutineDto("타이틀", "목포", days, "07:35", "생활");
-        Routine fakeRoutine = Routine.builder().account(account).newRoutine(newRoutine).id(1L).build();
-        Retrospect fakeRetrospect = Retrospect.builder().routine(fakeRoutine).isReport(false).result(Result.NOT).date("2021-11-29").build();
-        fakeRetrospect.updateRetrospect("테스트 회고 내용");
-        RetrospectDTO.RequestUpdateRetrospect fakeUpdateRetrospect = RetrospectDTO.RequestUpdateRetrospect.builder().retrospectId(1L).content("테스트 회고 수정").build();
+        try(MockedStatic<DateUtil> dateUtil = Mockito.mockStatic(DateUtil.class)) {
+            // given
+            Account account = AccountTemplate.makeTestAccount();
+            List<Week> days = new ArrayList<>();
+            days.add(Week.MON);
+            days.add(Week.TUE);
+            dateUtil.when(DateUtil::KST_LOCAL_DATE_NOW).thenReturn(LocalDate.parse("2021-11-30"));
+            RoutineDTO.RequestRoutineDto newRoutine = new RoutineDTO.RequestRoutineDto("타이틀", "목포", days, "07:35", "생활");
+            Routine fakeRoutine = Routine.builder().account(account).newRoutine(newRoutine).id(1L).build();
+            Retrospect fakeRetrospect = Retrospect.builder().routine(fakeRoutine).isReport(false).result(Result.NOT).date("2021-11-29").build();
+            fakeRetrospect.updateRetrospect("테스트 회고 내용");
+            RetrospectDTO.RequestUpdateRetrospect fakeUpdateRetrospect = RetrospectDTO.RequestUpdateRetrospect.builder().retrospectId(1L).content("테스트 회고 수정").build();
 
-        Retrospect fakeRetrospect2 = Retrospect.builder().routine(fakeRoutine).isReport(false).result(Result.NOT).date("2021-11-29").build();
-        fakeRetrospect2.updateRetrospect("테스트 회고 수정");
+            Retrospect fakeRetrospect2 = Retrospect.builder().routine(fakeRoutine).isReport(false).result(Result.NOT).date("2021-11-29").build();
+            fakeRetrospect2.updateRetrospect("테스트 회고 수정");
 
-        // mocking
-        given(retrospectRepository.findById(1L)).willReturn(Optional.of(fakeRetrospect));
-        given(retrospectRepository.save(any())).willReturn(fakeRetrospect2);
+            // mocking
+            given(retrospectRepository.findById(1L)).willReturn(Optional.of(fakeRetrospect));
+            given(retrospectRepository.save(any())).willReturn(fakeRetrospect2);
 
-        // when
-        RetrospectDTO.ResponseRetrospect fakeResponseRetrospect = retrospectService.updateRetrospect(fakeUpdateRetrospect, account).getData();
+            // when
+            RetrospectDTO.ResponseRetrospect fakeResponseRetrospect = retrospectService.updateRetrospect(fakeUpdateRetrospect, account).getData();
 
-        // then
-        assertThat(fakeRetrospect2.getContent()).isEqualTo(fakeResponseRetrospect.getContent());
+            // then
+            assertThat(fakeRetrospect2.getContent()).isEqualTo(fakeResponseRetrospect.getContent());
+        }
     }
 
     @Test


### PR DESCRIPTION
- 그 이유는 아이디의 값이 존재하면 해당 값이 이미 존재하는 지 확인하기 위해 SELECT문을 날리는 현상을 확인하게 됨
- 두 번째 이유는 테스트의 멱등성이 사라지게 됨 아이디 필드를 미리 가지고 있으면 해당 아이디 값이 이미 필드에 존재하면 테스트의 멱등성이 사라지기 때문에 통합용 템플릿 생성