### PR TITLE
[YAPPIOS-190] JPA N+1(루틴, 회고) 해결 및 타 레포 호출 서비스로 변경

### DIFF
--- a/src/main/java/com/yapp/project/organization/controller/OrganizationController.java
+++ b/src/main/java/com/yapp/project/organization/controller/OrganizationController.java
@@ -27,7 +27,7 @@ public class OrganizationController {
     @ApiOperation(value = "그룹 전체 리스트")
     @GetMapping
     public ResponseEntity<OrgListResponseMessage> findAll(){
-        List<OrgResponse> data = groupService.findAll(AccountUtil.getAccount());
+        List<OrgResponse> data = groupService.findAllByAccount(AccountUtil.getAccount());
         return new ResponseEntity<>(OrgListResponseMessage.of(StatusEnum.GROUP_OK, GROUP_FIND_SUCCESS, data), HttpStatus.OK);
     }
 

--- a/src/main/java/com/yapp/project/organization/service/GroupService.java
+++ b/src/main/java/com/yapp/project/organization/service/GroupService.java
@@ -21,10 +21,13 @@ public class GroupService {
     private final OrganizationRepository organizationRepository;
     private final MissionRepository missionRepository;
 
-
+    @Transactional(readOnly = true)
+    public List<Organization> findAll(){
+        return organizationRepository.findAll();
+    }
 
     @Transactional(readOnly = true)
-    public List<OrgDto.OrgResponse> findAll(Account account){
+    public List<OrgDto.OrgResponse> findAllByAccount(Account account){
         ArrayList<Long> excludeOrganization = getMyOrganizationId(account);
 
         List<Organization> organizations;

--- a/src/main/java/com/yapp/project/retrospect/domain/RetrospectRepository.java
+++ b/src/main/java/com/yapp/project/retrospect/domain/RetrospectRepository.java
@@ -2,7 +2,9 @@ package com.yapp.project.retrospect.domain;
 
 import com.yapp.project.account.domain.Account;
 import com.yapp.project.routine.domain.Routine;
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
 import java.time.LocalDate;
@@ -13,6 +15,8 @@ import java.util.Optional;
 public interface RetrospectRepository extends JpaRepository<Retrospect, Long> {
     Optional<Retrospect> findByRoutineAndDate(Routine routine, LocalDate date);
 
+    @EntityGraph(attributePaths = {"routine", "routine.days"})
+    @Query("select m from Retrospect m where m.date= :date and m.routine.account= :account")
     List<Retrospect> findAllByDateAndRoutineAccount(LocalDate date, Account account);
 
     List<Retrospect> findAllByIsReportIsFalseAndRoutineAccount(Account account);

--- a/src/main/java/com/yapp/project/routine/domain/Routine.java
+++ b/src/main/java/com/yapp/project/routine/domain/Routine.java
@@ -45,7 +45,7 @@ public class Routine {
     @Column(nullable = false)
     private String category;
 
-    @OneToMany(mappedBy = "routine", fetch = FetchType.EAGER,cascade = CascadeType.ALL, orphanRemoval = true)
+    @OneToMany(mappedBy = "routine", fetch = FetchType.EAGER, cascade = CascadeType.ALL, orphanRemoval = true)
     private List<RoutineDay> days = new ArrayList<>();
 
     @OneToMany(mappedBy = "routine")

--- a/src/main/java/com/yapp/project/routine/domain/RoutineRepository.java
+++ b/src/main/java/com/yapp/project/routine/domain/RoutineRepository.java
@@ -2,22 +2,22 @@ package com.yapp.project.routine.domain;
 
 import com.yapp.project.account.domain.Account;
 import org.springframework.data.domain.Sort;
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
-import java.time.LocalDate;
 import java.util.List;
 import java.util.Optional;
 
 @Repository
 public interface RoutineRepository extends JpaRepository<Routine, Long> {
+
     List<Routine> findAllByIsDeleteIsFalseAndAccountAndDaysDayOrderByDaysSequence(Account account, Week days, Sort sort);
 
+    @EntityGraph(attributePaths = {"days"})
+    @Query("select m from Routine m where m.id= :routineId")
     Optional<Routine> findByIdAndIsDeleteIsFalse(Long routineId);
 
-    List<Routine> findAllByAccountAndDaysDayAndRetrospectsDate(Account account, Week day, LocalDate parse);
-
     List<Routine> findAllByIsDeleteIsFalseAndAccount(Account account);
-
-    List<Routine> findAllByIsDeleteIsFalseAndAccountAndRetrospectsDateBetween(Account account, LocalDate start, LocalDate end);
 }

--- a/src/main/java/com/yapp/project/routine/service/RoutineService.java
+++ b/src/main/java/com/yapp/project/routine/service/RoutineService.java
@@ -7,7 +7,7 @@ import com.yapp.project.aux.common.DateUtil;
 import com.yapp.project.config.exception.report.RoutineStartDayBadRequestException;
 import com.yapp.project.config.exception.routine.BadRequestRoutineException;
 import com.yapp.project.organization.domain.Organization;
-import com.yapp.project.organization.domain.repository.OrganizationRepository;
+import com.yapp.project.organization.service.GroupService;
 import com.yapp.project.retrospect.domain.Result;
 import com.yapp.project.retrospect.domain.Retrospect;
 import com.yapp.project.retrospect.domain.RetrospectRepository;
@@ -33,13 +33,13 @@ public class RoutineService {
 
     private final RoutineRepository routineRepository;
     private final RetrospectRepository retrospectRepository;
-    private final OrganizationRepository organizationRepository;
+    private final GroupService groupService;
     private static final int WEEK_LENGTH = 7;
 
 
     @Transactional(readOnly = true)
     public RoutineDTO.ResponseRecommendedRoutineMessageDto getRecommendedRoutine() {
-        List<Organization> organList = organizationRepository.findAll();
+        List<Organization> organList = groupService.findAll();
         List<Organization> recommendedList = organList.stream().filter(organization ->
                 !organization.getCategory().equals("기상")).collect(Collectors.toList());
         return RoutineDTO.ResponseRecommendedRoutineMessageDto.of(recommendedList);

--- a/src/test/java/com/yapp/project/organization/service/GroupServiceTest.java
+++ b/src/test/java/com/yapp/project/organization/service/GroupServiceTest.java
@@ -43,7 +43,7 @@ class GroupServiceTest {
         given(missionRepository.findMissionByAccountAndIsFinishIsFalseAndIsDeleteIsFalse(account)).willReturn(emptyList);
         given(organizationRepository.findAll()).willReturn(organizations);
 
-        List<OrgDto.OrgResponse> res = groupService.findAll(account);
+        List<OrgDto.OrgResponse> res = groupService.findAllByAccount(account);
         assertThat(res.get(0).getTitle()).isEqualTo(organization.getTitle());
     }
 

--- a/src/test/java/com/yapp/project/routine/RoutineServiceTest.java
+++ b/src/test/java/com/yapp/project/routine/RoutineServiceTest.java
@@ -6,7 +6,7 @@ import com.yapp.project.aux.test.organization.OrganizationTemplate;
 import com.yapp.project.config.exception.report.RoutineStartDayBadRequestException;
 import com.yapp.project.config.exception.routine.BadRequestRoutineException;
 import com.yapp.project.organization.domain.Organization;
-import com.yapp.project.organization.domain.repository.OrganizationRepository;
+import com.yapp.project.organization.service.GroupService;
 import com.yapp.project.retrospect.domain.Retrospect;
 import com.yapp.project.retrospect.domain.RetrospectRepository;
 import com.yapp.project.routine.domain.Routine;
@@ -43,7 +43,7 @@ public class RoutineServiceTest {
     @Mock
     private RetrospectRepository retrospectRepository;
     @Mock
-    private OrganizationRepository organizationRepository;
+    private GroupService groupService;
 
     @Test
     void testCreateRoutineSuccess() {
@@ -270,7 +270,7 @@ public class RoutineServiceTest {
         recommendedList.add(test1); recommendedList.add(test2);
 
         // mocking
-        given(organizationRepository.findAll()).willReturn(recommendedList);
+        given(groupService.findAll()).willReturn(recommendedList);
 
         // when
         List<RoutineDTO.ResponseRecommendedRoutine> data = routineService.getRecommendedRoutine().getData();

--- a/src/test/java/com/yapp/project/routine/RoutineServiceTest.java
+++ b/src/test/java/com/yapp/project/routine/RoutineServiceTest.java
@@ -76,9 +76,7 @@ public class RoutineServiceTest {
         RoutineDTO.RequestRoutineDto newRoutine = new RoutineDTO.RequestRoutineDto("", "", days, "07:35", "생활");
 
         // when then
-        assertThrows(BadRequestRoutineException.class, () -> {
-            routineService.createRoutine(newRoutine, account);
-        });
+        assertThrows(BadRequestRoutineException.class, () -> routineService.createRoutine(newRoutine, account));
     }
 
     @Test
@@ -109,9 +107,7 @@ public class RoutineServiceTest {
         Account account = AccountTemplate.makeTestAccount();
 
         // when then
-        assertThrows(NotFoundRoutineException.class, () -> {
-            routineService.getRoutine(1L, account);
-        });
+        assertThrows(NotFoundRoutineException.class, () -> routineService.getRoutine(1L, account));
     }
 
     @Test
@@ -129,9 +125,7 @@ public class RoutineServiceTest {
         given(routineRepository.findByIdAndIsDeleteIsFalse(1L)).willReturn(Optional.of(fakeRoutine));
 
         // when then
-        assertThrows(BadRequestRoutineException.class, () -> {
-            routineService.getRoutine(1L, account2);
-        });
+        assertThrows(BadRequestRoutineException.class, () -> routineService.getRoutine(1L, account2));
     }
 
     @Test
@@ -256,9 +250,7 @@ public class RoutineServiceTest {
         LocalDate start = LocalDate.parse("2021-10-19");
 
         // when then
-        assertThrows(RoutineStartDayBadRequestException.class, () -> {
-            routineService.getRoutineDaysRate(account, start);
-        });
+        assertThrows(RoutineStartDayBadRequestException.class, () -> routineService.getRoutineDaysRate(account, start));
     }
 
     @Test


### PR DESCRIPTION
JPA N+1(루틴, 회고) 해결 및 타 레포 호출 서비스로 변경

- JPA N+1 루틴 및 회고 문제 수정
- 루틴 관련 서비스에서 타 서비스의 레포를 직접 호출 -> 서비스 로직을 통해 간접 호출
ex) routine에서 groupRepository -> routine에서 groupService