### PR TITLE
[YAPPIOS-231] 루틴 응답 DTO 수정

### DIFF
--- a/src/main/java/com/yapp/project/routine/controller/RoutineController.java
+++ b/src/main/java/com/yapp/project/routine/controller/RoutineController.java
@@ -32,9 +32,9 @@ public class RoutineController {
     }
 
     @ApiOperation(value = "루틴 요일별 전체 조회", notes = "요일별 루틴 전체 조회하기")
-    @GetMapping("/day/{day}")
-    public RoutineDTO.ResponseRoutineListMessageDto getRoutineList(@PathVariable Week day) {
-        return routineService.getRoutineList(day, AccountUtil.getAccount());
+    @GetMapping("/day/{date}")
+    public RoutineDTO.ResponseRoutineDateListMessageDto getRoutineList(@PathVariable String date) {
+        return routineService.getRoutineList(date, AccountUtil.getAccount());
     }
 
     @ApiOperation(value = "루틴 수정", notes = "루틴 수정하기")
@@ -51,7 +51,7 @@ public class RoutineController {
 
     @ApiOperation(value = "요일 루틴 순서 편집", notes = "요일 루틴 순서 편집하기\n 루틴ID를 순서대로 넘겨주세요")
     @PatchMapping("/sequence/{day}")
-    public RoutineDTO.ResponseRoutineListMessageDto updateRoutineSequence(
+    public Message updateRoutineSequence(
             @PathVariable Week day, @RequestBody RoutineDTO.RequestRoutineSequence sequence) {
         return routineService.updateRoutineSequence(day, sequence.getSequence(), AccountUtil.getAccount());
     }

--- a/src/main/java/com/yapp/project/routine/domain/RoutineDTO.java
+++ b/src/main/java/com/yapp/project/routine/domain/RoutineDTO.java
@@ -3,12 +3,15 @@ package com.yapp.project.routine.domain;
 import com.yapp.project.aux.Message;
 import com.yapp.project.aux.StatusEnum;
 import com.yapp.project.organization.domain.Organization;
+import com.yapp.project.retrospect.domain.Result;
+import com.yapp.project.retrospect.domain.Retrospect;
 import io.swagger.annotations.ApiModelProperty;
 import lombok.*;
 
 import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 import java.util.stream.Collectors;
 
 import static com.yapp.project.aux.content.RoutineContent.DAY_ROUTINE_RATE_OK;
@@ -131,6 +134,44 @@ public class RoutineDTO {
 
     @Getter
     @Setter
+    public static class ResponseRoutineDateDto {
+        @ApiModelProperty(value = "루틴ID", example = "1")
+        private Long id;
+
+        @ApiModelProperty(value = "타이틀", example = "명상")
+        private String title;
+
+        @ApiModelProperty(value = "수행여부", example = "DONE")
+        private Result result;
+
+        @ApiModelProperty(value = "목표", example = "고요히 자기 자신을 느껴보는 시간입니다.")
+        private String goal;
+
+        @ApiModelProperty(value = "하는 요일", example = "['MON', 'SUN']")
+        private List<Week> days = new ArrayList<>();
+
+        @ApiModelProperty(value = "하는 시간", example = "07:35")
+        private String startTime;
+
+        @ApiModelProperty(value = "카테고리", example = "0")
+        private Integer category;
+
+        @Builder
+        public ResponseRoutineDateDto(Routine routine, List<Retrospect> retrospectList) {
+            this.id = routine.getId();
+            this.title = routine.getTitle();
+            this.goal = routine.getGoal();
+            this.startTime = routine.getStartTime().toString();
+            this.days = routine.getDays().stream().map(RoutineDay::getDay).collect(Collectors.toList());
+            this.category = routine.getCategory().getIndex();
+            Retrospect retrospect = retrospectList.stream()
+                    .filter(x -> Objects.equals(x.getRoutine().getId(), this.id)).findFirst().orElse(null);
+            this.result = retrospect != null ? retrospect.getResult() : Result.NOT;
+        }
+    }
+
+    @Getter
+    @Setter
     @AllArgsConstructor
     @Builder
     public static class ResponseRoutineMessageDto {
@@ -145,6 +186,15 @@ public class RoutineDTO {
     public static class ResponseRoutineListMessageDto {
         private Message message;
         private List<ResponseRoutineDto> data;
+    }
+
+    @Getter
+    @Setter
+    @AllArgsConstructor
+    @Builder
+    public static class ResponseRoutineDateListMessageDto {
+        private Message message;
+        private List<ResponseRoutineDateDto> data;
     }
 
     @Getter

--- a/src/main/java/com/yapp/project/routine/domain/RoutineRepository.java
+++ b/src/main/java/com/yapp/project/routine/domain/RoutineRepository.java
@@ -12,7 +12,7 @@ import java.util.Optional;
 
 @Repository
 public interface RoutineRepository extends JpaRepository<Routine, Long> {
-
+    @EntityGraph(attributePaths = {"days"})
     List<Routine> findAllByIsDeleteIsFalseAndAccountAndDaysDayOrderByDaysSequence(Account account, Week days, Sort sort);
 
     @EntityGraph(attributePaths = {"days"})

--- a/src/main/java/com/yapp/project/routine/domain/Week.java
+++ b/src/main/java/com/yapp/project/routine/domain/Week.java
@@ -1,5 +1,11 @@
 package com.yapp.project.routine.domain;
 
+import org.jetbrains.annotations.NotNull;
+
+import java.time.LocalDate;
+import java.time.format.TextStyle;
+import java.util.Locale;
+
 public enum Week {
     MON("MON", 0),
     TUE("TUE", 1),
@@ -23,6 +29,12 @@ public enum Week {
 
     public int getIndex() {
         return index;
+    }
+
+    @NotNull
+    public static Week getWeek(String date) {
+        String strDay = LocalDate.parse(date).getDayOfWeek().getDisplayName(TextStyle.SHORT, Locale.ENGLISH).toUpperCase();
+        return Week.valueOf(strDay);
     }
 
 }

--- a/src/main/java/com/yapp/project/routine/service/RoutineService.java
+++ b/src/main/java/com/yapp/project/routine/service/RoutineService.java
@@ -15,6 +15,7 @@ import com.yapp.project.retrospect.domain.RetrospectRepository;
 import com.yapp.project.routine.domain.*;
 import com.yapp.project.config.exception.routine.NotFoundRoutineException;
 import lombok.RequiredArgsConstructor;
+import org.jetbrains.annotations.NotNull;
 import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -63,12 +64,12 @@ public class RoutineService {
     }
 
     @Transactional
-    public RoutineDTO.ResponseRoutineListMessageDto updateRoutineSequence(Week day, ArrayList<Long> sequence, Account account) {
+    public Message updateRoutineSequence(Week day, ArrayList<Long> sequence, Account account) {
         List<Routine> routineList = findAllIsExistById(sequence);
         routineList.forEach(x -> checkIsMine(account, x));
         updateRoutineDaysSequence(day, sequence, routineList);
         routineRepository.saveAll(routineList);
-        return getRoutineList(day, account);
+        return Message.builder().msg(ROUTINE_UPDATE_OK).status(StatusEnum.ROUTINE_OK).build();
     }
 
     @Transactional
@@ -94,13 +95,16 @@ public class RoutineService {
     }
 
     @Transactional(readOnly = true)
-    public RoutineDTO.ResponseRoutineListMessageDto getRoutineList(Week day, Account account) {
+    public RoutineDTO.ResponseRoutineDateListMessageDto getRoutineList(String date, Account account) {
+        Week day = getWeek(date);
         List<Routine> routineList = routineRepository // Sort.by("days").descending(): sequence가 0인 루틴은 최신 등록순
                 .findAllByIsDeleteIsFalseAndAccountAndDaysDayOrderByDaysSequence(account, day, Sort.by("days").descending());
-        return RoutineDTO.ResponseRoutineListMessageDto.builder()
+        List<Retrospect> retrospectList = retrospectRepository.
+                findAllByDateAndRoutineAccount(DateUtil.convertStr2LocalDate(date), account);
+        return RoutineDTO.ResponseRoutineDateListMessageDto.builder()
                 .message(Message.builder().msg(ROUTINE_BY_DAY_OK).status(StatusEnum.ROUTINE_OK).build())
-                .data(routineList.stream().map(routine -> RoutineDTO.ResponseRoutineDto.builder()
-                        .routine(routine).build()).collect(Collectors.toList()))
+                .data(routineList.stream().map(routine -> RoutineDTO.ResponseRoutineDateDto.builder()
+                        .routine(routine).retrospectList(retrospectList).build()).collect(Collectors.toList()))
                 .build();
     }
 
@@ -222,5 +226,11 @@ public class RoutineService {
         if(!isMon.equals(Week.MON)){
             throw new RoutineStartDayBadRequestException();
         }
+    }
+
+    @NotNull
+    private Week getWeek(String date) {
+        String strDay = LocalDate.parse(date).getDayOfWeek().getDisplayName(TextStyle.SHORT, Locale.ENGLISH).toUpperCase();
+        return Week.valueOf(strDay);
     }
 }

--- a/src/main/java/com/yapp/project/routine/service/RoutineService.java
+++ b/src/main/java/com/yapp/project/routine/service/RoutineService.java
@@ -96,7 +96,7 @@ public class RoutineService {
 
     @Transactional(readOnly = true)
     public RoutineDTO.ResponseRoutineDateListMessageDto getRoutineList(String date, Account account) {
-        Week day = getWeek(date);
+        Week day = Week.getWeek(date);
         List<Routine> routineList = routineRepository // Sort.by("days").descending(): sequence가 0인 루틴은 최신 등록순
                 .findAllByIsDeleteIsFalseAndAccountAndDaysDayOrderByDaysSequence(account, day, Sort.by("days").descending());
         List<Retrospect> retrospectList = retrospectRepository.
@@ -228,9 +228,5 @@ public class RoutineService {
         }
     }
 
-    @NotNull
-    private Week getWeek(String date) {
-        String strDay = LocalDate.parse(date).getDayOfWeek().getDisplayName(TextStyle.SHORT, Locale.ENGLISH).toUpperCase();
-        return Week.valueOf(strDay);
-    }
+
 }

--- a/src/test/java/com/yapp/project/routine/RoutineServiceTest.java
+++ b/src/test/java/com/yapp/project/routine/RoutineServiceTest.java
@@ -1,6 +1,7 @@
 package com.yapp.project.routine;
 
 import com.yapp.project.account.domain.Account;
+import com.yapp.project.aux.Message;
 import com.yapp.project.aux.test.account.AccountTemplate;
 import com.yapp.project.aux.test.organization.OrganizationTemplate;
 import com.yapp.project.config.exception.report.RoutineStartDayBadRequestException;
@@ -143,7 +144,7 @@ class RoutineServiceTest {
         given(routineRepository
                 .findAllByIsDeleteIsFalseAndAccountAndDaysDayOrderByDaysSequence(account, Week.MON, Sort.by("days").descending())).willReturn(routines);
         // when
-        List<RoutineDTO.ResponseRoutineDto> routineList = routineService.getRoutineList(Week.MON, account).getData();
+        List<RoutineDTO.ResponseRoutineDateDto> routineList = routineService.getRoutineList("2021-12-13", account).getData();
         // then
         assertThat(routineList.size()).isEqualTo(routines.size());
     }
@@ -186,14 +187,12 @@ class RoutineServiceTest {
 
         // mocking
         given(routineRepository.findAllById(sequence)).willReturn(routines);
-        given(routineRepository
-                .findAllByIsDeleteIsFalseAndAccountAndDaysDayOrderByDaysSequence(account, Week.MON, Sort.by("days").descending())).willReturn(routines);
 
         // when
-        List<RoutineDTO.ResponseRoutineDto> responseRoutineDtos = routineService.updateRoutineSequence(Week.MON, sequence, account).getData();
+        Message message = routineService.updateRoutineSequence(Week.MON, sequence, account);
 
         // then
-        assertThat(responseRoutineDtos.get(0).getTitle()).isEqualTo(newRoutine2.getTitle());
+        assertThat(message.getMsg()).isEqualTo(message.getMsg(), "루틴을 성공적으로 수정하였습니다.");
     }
 
     @Test


### PR DESCRIPTION
루틴 응답 DTO 수정

- 루틴 요일별 전체 조회 속성 추가
  - 수행 결과

기존에는 요일별 루틴 전체 조회를 하면 기본적인 루틴 정보만 응답하였습니다.
하지만 홈 화면에서 보이는 루틴은 수행 여부를 필요로 합니다.

총 2개의 API 요청 및 응답 형식이 수정되었습니다.
아래 기재된 API 제외 루틴 응답 형식은 기존과 동일합니다.

### 루틴 요일별 전체 조회 (/api/v1/routine/day/{date})
  - **응답 형식의 루틴 리스트 부분에서 result속성이 추가되었습니다.**
  - **URI가 변경되었습니다. /day/MON -> /day/2021-12-13**
``` json
{
  "data": [
    {
      ...
      "result": "DONE"
    }, {
      ...
    }
  ]
  "message": {
    ...
  }
}
```
### 요일 루틴 순서 업데이트 (/api/v1/routine/sequence/{day})
**기존에는** 요일 루틴 순서를 변경하면 변경된 **순서대로 루틴 리스트를 응답**하였습니다.
**변경된 응답**은 **상태 메세지만 응답**하며 루틴 리스트를 응답하지 않습니다.
```json
{
  "msg": ...,
  "status": "...
}
```
따라서 클라이언트에서는 정상 응답을 받으면 요청했던 순서대로 루틴 순서를 변경해주시면 될 것 같습니다.

