### PR TITLE
[YAPPIOS-232] CloudStorage Util 구현 및 Retrospect 연결

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@ dockerfiles/.env
 src/main/resources/application.yaml
 src/test/resources/application.yaml
 src/main/resources/firebase
+src/main/resources/storage
 .idea
 HELP.md
 .gradle
@@ -23,7 +24,6 @@ bin/
 !**/src/test/**/bin/
 
 ### IntelliJ IDEA ###
-.idea
 *.iws
 *.iml
 *.ipr

--- a/build.gradle
+++ b/build.gradle
@@ -70,6 +70,8 @@ dependencies {
 	implementation 'com.google.firebase:firebase-admin:6.8.1'
 	implementation group: 'com.squareup.okhttp3', name: 'okhttp', version: '4.2.2'
 
+	// [Cloud Storage]
+	implementation 'com.google.cloud:google-cloud-storage'
 
 }
 

--- a/jenkinsfiles/Jenkinsfile_develop
+++ b/jenkinsfiles/Jenkinsfile_develop
@@ -14,11 +14,15 @@ pipeline {
       }
     }
 
-    stage('set firebase key') {
+    stage('set service key') {
       steps {
         sh 'mkdir ./src/main/resources/firebase'
         sh 'cp ../properties/firebase/firebase_service_key.json ./src/main/resources/firebase'
       }
+      steps {
+              sh 'mkdir ./src/main/resources/storage'
+              sh 'cp ../properties/storage/minning_storage_key.json ./src/main/resources/storage'
+            }
     }
 
     stage('build') {

--- a/src/main/java/com/yapp/project/aux/common/SnapShotUtil.java
+++ b/src/main/java/com/yapp/project/aux/common/SnapShotUtil.java
@@ -10,8 +10,10 @@ import java.nio.file.Paths;
 
 import static com.yapp.project.aux.common.DateUtil.KST_LOCAL_DATE_NOW;
 
+@Deprecated
 public class SnapShotUtil {
     private SnapShotUtil(){}
+    @Deprecated
     public static String saveImages(MultipartFile image, Long id, String filePath) throws IOException {
         int dotIndex = image.getOriginalFilename().lastIndexOf(".");
         String fileName = image.getOriginalFilename().substring(0, dotIndex);

--- a/src/main/java/com/yapp/project/aux/storage/CloudStorageUtil.java
+++ b/src/main/java/com/yapp/project/aux/storage/CloudStorageUtil.java
@@ -1,0 +1,49 @@
+package com.yapp.project.aux.storage;
+
+import com.google.auth.oauth2.GoogleCredentials;
+import com.google.cloud.storage.Acl;
+import com.google.cloud.storage.BlobInfo;
+import com.google.cloud.storage.Storage;
+import com.google.cloud.storage.StorageOptions;
+import com.yapp.project.aux.common.DateUtil;
+import org.springframework.stereotype.Component;
+import org.springframework.util.ResourceUtils;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.ArrayList;
+import java.util.List;
+
+@Component
+public class CloudStorageUtil {
+
+    private static final String KEY_PATH = "classpath:storage/minning-335309-b237a3e1bfa5.json";
+    private static final String BUCKET = "minning";
+    private static final ArrayList<Acl> ACL = new ArrayList<>(List.of(Acl.of(Acl.User.ofAllAuthenticatedUsers(), Acl.Role.READER)));
+
+    /**
+     * @RequestParam
+     * img : Image of MultipartFile type
+     * dir : Image Path / ex) retrospect -> retrospect/{routineId}/
+     * */
+    public BlobInfo upload(MultipartFile image, String dir) throws IOException {
+        String img = makeImageFileName(image);
+        InputStream keyFile = ResourceUtils.getURL(KEY_PATH).openStream();
+        Storage storage = StorageOptions.newBuilder().setProjectId(BUCKET)
+                .setCredentials(GoogleCredentials.fromStream(keyFile))
+                .build().getService();
+        return storage.create(
+                BlobInfo.newBuilder(BUCKET, dir + img)
+                        .setAcl(ACL)
+                        .build(),
+                image.getBytes());
+    }
+
+    private String makeImageFileName(MultipartFile image) {
+        int dotIndex = image.getOriginalFilename().lastIndexOf(".");
+        String fileName = image.getOriginalFilename().substring(0, dotIndex);
+        String extension = image.getOriginalFilename().substring(dotIndex);
+        return fileName + "_" + DateUtil.KST_LOCAL_DATETIME_NOW() + extension;
+    }
+}

--- a/src/main/java/com/yapp/project/aux/storage/CloudStorageUtil.java
+++ b/src/main/java/com/yapp/project/aux/storage/CloudStorageUtil.java
@@ -21,7 +21,7 @@ public class CloudStorageUtil {
     @Value("${property.cloud.bucket}")
     private String BUCKET;
     public static String BASE_URI = "https://storage.googleapis.com/";
-    private static final ArrayList<Acl> ACL = new ArrayList<>(List.of(Acl.of(Acl.User.ofAllAuthenticatedUsers(), Acl.Role.READER)));
+    private static final List<Acl> ACL = new ArrayList<>(List.of(Acl.of(Acl.User.ofAllAuthenticatedUsers(), Acl.Role.READER)));
 
     /**
      * @RequestParam

--- a/src/main/java/com/yapp/project/aux/storage/CloudStorageUtil.java
+++ b/src/main/java/com/yapp/project/aux/storage/CloudStorageUtil.java
@@ -1,11 +1,9 @@
 package com.yapp.project.aux.storage;
 
 import com.google.auth.oauth2.GoogleCredentials;
-import com.google.cloud.storage.Acl;
-import com.google.cloud.storage.BlobInfo;
-import com.google.cloud.storage.Storage;
-import com.google.cloud.storage.StorageOptions;
+import com.google.cloud.storage.*;
 import com.yapp.project.aux.common.DateUtil;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 import org.springframework.util.ResourceUtils;
 import org.springframework.web.multipart.MultipartFile;
@@ -18,8 +16,11 @@ import java.util.List;
 @Component
 public class CloudStorageUtil {
 
-    private static final String KEY_PATH = "classpath:storage/minning-335309-b237a3e1bfa5.json";
-    private static final String BUCKET = "minning";
+    @Value("${property.cloud.key.path}")
+    private String KEY_PATH;
+    @Value("${property.cloud.bucket}")
+    private String BUCKET;
+    public static String BASE_URI = "https://storage.googleapis.com/";
     private static final ArrayList<Acl> ACL = new ArrayList<>(List.of(Acl.of(Acl.User.ofAllAuthenticatedUsers(), Acl.Role.READER)));
 
     /**
@@ -45,5 +46,9 @@ public class CloudStorageUtil {
         String fileName = image.getOriginalFilename().substring(0, dotIndex);
         String extension = image.getOriginalFilename().substring(dotIndex);
         return fileName + "_" + DateUtil.KST_LOCAL_DATETIME_NOW() + extension;
+    }
+
+    public static String getImageURL(BlobInfo image) {
+        return BASE_URI + image.getBucket() + "/" + image.getName();
     }
 }

--- a/src/main/java/com/yapp/project/batch/scheduler/GroupScheduler.java
+++ b/src/main/java/com/yapp/project/batch/scheduler/GroupScheduler.java
@@ -23,7 +23,7 @@ public class GroupScheduler {
         this.alertService = alertService;
     }
 
-    @Scheduled(cron = "0 0 16 * * *")
+    @Scheduled(cron = "0 0 1 * * *", zone = "Asia/Seoul")
     public void groupBatchExecuteJob() throws JobExecutionException{
         alertService.slackSendMessage(SlackChannel.BATCH,":arrow_forward:배치작업 시작합니다.");
         jobLauncher.run(job, new JobParametersBuilder()

--- a/src/main/java/com/yapp/project/batch/scheduler/MissionNotificationScheduler.java
+++ b/src/main/java/com/yapp/project/batch/scheduler/MissionNotificationScheduler.java
@@ -28,7 +28,7 @@ public class MissionNotificationScheduler {
         this.alertService = alertService;
     }
 
-    @Scheduled(cron = "0 0 0 * * *")
+    @Scheduled(cron = "0 0 9 * * *", zone = "Asia/Seoul")
     public void missionFinishBatchExecuteJob() throws JobExecutionException{
         alertService.slackSendMessage(SlackChannel.BATCH,":arrow_forward:종료된 미션에 대한 배치작업 시작합니다.");
         jobLauncher.run(job, new JobParametersBuilder()
@@ -37,7 +37,7 @@ public class MissionNotificationScheduler {
         alertService.slackSendMessage(SlackChannel.BATCH,":ballot_box_with_check:종료된 미션에 대한 배치작업 끝났습니다.");
     }
 
-    @Scheduled(cron = "0 50 18,19,20,21,22 * * *")
+    @Scheduled(cron = "0 50 3,4,5,6,7 * * *", zone = "Asia/Seoul")
     public void missionFourWakeUpBatchExecuteJob() throws JobExecutionException{
         alertService.slackSendMessage(SlackChannel.BATCH,":arrow_forward:기상 미션에 대한 배치작업 시작합니다.");
         jobLauncher.run(job2, new JobParametersBuilder()

--- a/src/main/java/com/yapp/project/batch/scheduler/MissionScheduler.java
+++ b/src/main/java/com/yapp/project/batch/scheduler/MissionScheduler.java
@@ -23,7 +23,7 @@ public class MissionScheduler {
         this.alertService = alertService;
     }
 
-    @Scheduled(cron = "0 1 15 * * *")
+    @Scheduled(cron = "0 1 0 * * *", zone = "Asia/Seoul")
     public void missionBatchExecuteJob() throws JobExecutionException{
         alertService.slackSendMessage(SlackChannel.BATCH,
                 ":arrow_forward:어제 수행한 날인데 수행하지 않은 사람들 실패한 횟수 증가하는 배치작업 시작합니다.");

--- a/src/main/java/com/yapp/project/batch/scheduler/OrganizationScheduler.java
+++ b/src/main/java/com/yapp/project/batch/scheduler/OrganizationScheduler.java
@@ -19,7 +19,7 @@ public class OrganizationScheduler {
         this.jobLauncher = jobLauncher;
     }
 
-    @Scheduled(cron = "0 1 * * * *")
+    @Scheduled(cron = "0 1 * * * *", zone = "Asia/Seoul")
     public void groupBatchExecuteJob() throws JobExecutionException{
         jobLauncher.run(job, new JobParametersBuilder()
                             .addString("organizationUpdateRate", DateUtil.KST_LOCAL_DATETIME_NOW().toString())

--- a/src/main/java/com/yapp/project/batch/scheduler/ReportNotificationScheduler.java
+++ b/src/main/java/com/yapp/project/batch/scheduler/ReportNotificationScheduler.java
@@ -28,7 +28,7 @@ public class ReportNotificationScheduler {
         this.alertService = alertService;
     }
 
-    @Scheduled(cron = "0 16 2 * * 3")
+    @Scheduled(cron = "0 16 11 * * 3", zone = "Asia/Seoul")
     public void weekReportNotificationJob() throws JobExecutionException{
         alertService.slackSendMessage(SlackChannel.BATCH, WEEK_REPORT_PUSH_START);
         jobLauncher.run(weekNotificationJob, new JobParametersBuilder()
@@ -37,7 +37,7 @@ public class ReportNotificationScheduler {
         alertService.slackSendMessage(SlackChannel.BATCH, WEEK_REPORT_PUSH_END);
     }
 
-    @Scheduled(cron = "0 20 2 ? * 3#1")
+    @Scheduled(cron = "0 20 11 ? * 3#1", zone = "Asia/Seoul")
     public void monthReportNotificationJob() throws JobExecutionException{
         alertService.slackSendMessage(SlackChannel.BATCH, MONTH_REPORT_PUSH_START);
         jobLauncher.run(monthNotificationJob, new JobParametersBuilder()

--- a/src/main/java/com/yapp/project/batch/scheduler/ReportScheduler.java
+++ b/src/main/java/com/yapp/project/batch/scheduler/ReportScheduler.java
@@ -28,7 +28,7 @@ public class ReportScheduler {
         this.alertService = alertService;
     }
 
-    @Scheduled(cron = "0 0 17 * * 2")
+    @Scheduled(cron = "0 0 2 * * 3", zone = "Asia/Seoul")
     public void makeWeekReportJob() throws JobExecutionException{
         alertService.slackSendMessage(SlackChannel.BATCH, WEEK_REPORT_CREATE_START);
         jobLauncher.run(weekReportJob, new JobParametersBuilder()
@@ -37,7 +37,7 @@ public class ReportScheduler {
         alertService.slackSendMessage(SlackChannel.BATCH, WEEK_REPORT_CREATE_END);
     }
 
-    @Scheduled(cron = "0 0 18 ? * 2#1")
+    @Scheduled(cron = "0 0 3 ? * 3#1")
     public void makeMonthReportJob() throws JobExecutionException{
         alertService.slackSendMessage(SlackChannel.BATCH, MONTH_REPORT_CREATE_START);
         jobLauncher.run(monthReportJob, new JobParametersBuilder()

--- a/src/main/java/com/yapp/project/retrospect/controller/RetrospectController.java
+++ b/src/main/java/com/yapp/project/retrospect/controller/RetrospectController.java
@@ -1,18 +1,17 @@
 package com.yapp.project.retrospect.controller;
 
+import com.google.cloud.storage.BlobInfo;
 import com.yapp.project.aux.Message;
 import com.yapp.project.aux.common.AccountUtil;
+import com.yapp.project.aux.storage.CloudStorageUtil;
 import com.yapp.project.retrospect.domain.dto.RetrospectDTO;
 import com.yapp.project.retrospect.service.RetrospectService;
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 import lombok.RequiredArgsConstructor;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.web.bind.annotation.*;
 import java.io.IOException;
 import java.time.LocalDate;
-
-import static com.yapp.project.aux.common.SnapShotUtil.saveImages;
 
 @RestController
 @RequiredArgsConstructor
@@ -22,19 +21,13 @@ public class RetrospectController {
 
     private final RetrospectService retrospectService;
 
-    @Value("${property.image.path}")
-    private String path;
+
+    private static final String path = "retrospect/";
 
     @ApiOperation(value = "회고 추가", notes = "json이 아닌 multipart/form-data로 보내주서야 합니다.")
     @PostMapping("/")
     public RetrospectDTO.ResponseRetrospectMessage createRetrospect(RetrospectDTO.RequestRetrospect retrospect) throws IOException {
-        String imagePath;
-        if(retrospect.getImage() == null) {
-            imagePath = null;
-        } else{
-            imagePath = saveImages(retrospect.getImage(), retrospect.getRoutineId(), path+"retrospect/");
-        }
-        return retrospectService.createRetrospect(retrospect, imagePath, AccountUtil.getAccount());
+        return retrospectService.createRetrospect(retrospect, AccountUtil.getAccount());
     }
 
     @ApiOperation(value = "회고 수정", notes = "json이 아닌 multipart/form-data로 보내주서야 합니다.")

--- a/src/test/java/com/yapp/project/retrospect/RetrospectServiceTest.java
+++ b/src/test/java/com/yapp/project/retrospect/RetrospectServiceTest.java
@@ -5,7 +5,6 @@ import com.yapp.project.aux.common.DateUtil;
 import com.yapp.project.aux.test.account.AccountTemplate;
 import com.yapp.project.config.exception.retrospect.BadRequestRetrospectException;
 import com.yapp.project.config.exception.retrospect.NotFoundRetrospectException;
-import com.yapp.project.report.domain.WeekReport;
 import com.yapp.project.retrospect.domain.Result;
 import com.yapp.project.retrospect.domain.Retrospect;
 import com.yapp.project.retrospect.domain.RetrospectRepository;
@@ -59,24 +58,22 @@ class RetrospectServiceTest {
             List<RoutineDay> newDays = days.stream().map(day -> RoutineDay.builder().day(day).sequence(0L).routine(fakeRoutine).build()).collect(Collectors.toList());
             fakeRoutine.addDays(newDays);
             Retrospect fakeRetrospect = Retrospect.builder().routine(fakeRoutine).isReport(false).result(Result.NOT).date("2021-10-12").build();
-            Snapshot fakeSnapShot = Snapshot.builder().url("테스트 경로").build();
-            Retrospect fakeRetrospectSnapShot = Retrospect.builder().routine(fakeRoutine).isReport(false).result(Result.NOT).date("2021-10-12").build();
-            fakeRetrospectSnapShot.updateRetrospect("테스트 회고 내용", fakeSnapShot);
+            Retrospect fakeRetrospectSnapShot = Retrospect.builder().routine(fakeRoutine).isReport(false).result(Result.NOT).content("테스트 회고 내용").date("2021-10-12").build();
             RetrospectDTO.RequestRetrospect fakeRequestRetrospect =
                     RetrospectDTO.RequestRetrospect.builder().routineId(1L).date("2021-10-12").content("테스트 회고 내용").build();
 
             // mocking
             dateUtil.when(DateUtil::KST_LOCAL_DATE_NOW).thenReturn(LocalDate.parse("2021-10-12"));
             given(retrospectRepository.findByRoutineAndDate(fakeRoutine, LocalDate.parse("2021-10-12"))).willReturn(Optional.of(fakeRetrospect));
-            given(snapshotRepository.save(any())).willReturn(fakeSnapShot);
             given(retrospectRepository.save(any())).willReturn(fakeRetrospectSnapShot);
             given(routineService.findIsExistByIdAndIsNotDelete(1L)).willReturn(fakeRoutine);
 
             // when
-            RetrospectDTO.ResponseRetrospect fakeResponseRetrospect = retrospectService.createRetrospect(fakeRequestRetrospect, "테스트 경로", account).getData();
+            RetrospectDTO.ResponseRetrospect fakeResponseRetrospect = retrospectService.createRetrospect(fakeRequestRetrospect, account).getData();
 
             assertThat(fakeRequestRetrospect.getContent()).isEqualTo(fakeResponseRetrospect.getContent());
             assertThat(fakeRequestRetrospect.getRoutineId()).isEqualTo(fakeResponseRetrospect.getRoutine().getId());
+        } catch (IOException e) {
         }
     }
 


### PR DESCRIPTION
CloudStorage Util 구현 및 Retrospect 연결

- CloudStorageUtil 구현
  - uploade(...)
  - getImageURL : DB에 Image경로 저장 시, 본 메서드의 응답 값 저장
  - 이미지 이름 및 디렉토리 전략은 Confluence 백로그에 작성되어 있는대로 진행하였습니다.
- SnapShot Deprecated
  - SnapShot은 CloudStorageUtil을 사용하면서 필요가 없게 되었습니다.
  아직 Mission에서는 작업 전이라 SnapShotUtil **Deprecated** 적용 해놓았습니다.
  Mission 이미지 저장 리팩토링 끝나면 SnapShot 제거하시면 됩니다.
- Scheduler TimeZone
  - 이 부분은 자잘한 리팩토링이라 같이 작업하였습니다.
  - instance시간을 Asia/Seoul로 변경했는데 Scheduler가 UTC기준으로 동작해서 Scheduler에 명시적으로 TimeZone을 Asia/Seoul로 설정하였습니다

추가로 서버에 저장 될 서비스 키(json)은 jenkins서버에 저장하였고, 변경 된 application.yaml은 Confluence에 최신화 하겠습니다.
CloudStorageUtil 궁금하신 점 있으시면 말씀해주세요~