### PR TITLE
[YAPPIOS-237] 월 리포트 조회 추가적인 예외 케이스 대응

### DIFF
--- a/src/main/java/com/yapp/project/report/controller/ReportController.java
+++ b/src/main/java/com/yapp/project/report/controller/ReportController.java
@@ -11,6 +11,7 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import java.text.ParseException;
 import java.time.LocalDate;
 
 @RestController
@@ -26,7 +27,7 @@ public class ReportController {
             "\n[miracle, self, health, daily, etc]")
     @GetMapping("/month/{year}/{month}")
     public ReportDTO.ResponseMonthReportMessage getMonthReportByYearAndMonth(
-            @PathVariable Integer year, @PathVariable Integer month) {
+            @PathVariable Integer year, @PathVariable Integer month) throws ParseException {
         return reportService.getMonthReportByYearAndMonth(AccountUtil.getAccount(), year, month);
     }
 

--- a/src/main/java/com/yapp/project/report/domain/WeekReport.java
+++ b/src/main/java/com/yapp/project/report/domain/WeekReport.java
@@ -41,18 +41,21 @@ public class WeekReport {
 
     private Integer monthReportMonth;
 
+    private Integer weekNum;
+
     @Builder
     public WeekReport() {
         this.lastDate = DateUtil.KST_LOCAL_DATE_NOW().with(TemporalAdjusters.previous(DayOfWeek.MONDAY)).minusDays(1); // 가장 최근 월요일
         this.isReport = false;
     }
 
-    public void addBasicData(Account account, Integer rate, int notDoneCount, int fullyDoneCount, int partiallyDoneCount) {
+    public void addBasicData(Account account, Integer rate, int notDoneCount, int fullyDoneCount, int partiallyDoneCount, int weekNum) {
         this.account = account;
         this.rate = rate;
         this.notDoneCount = notDoneCount;
         this.fullyDoneCount = fullyDoneCount;
         this.partiallyDoneCount = partiallyDoneCount;
+        this.weekNum = weekNum;
     }
 
     public void addRoutineResult(RoutineResult routineResult) {

--- a/src/main/java/com/yapp/project/report/domain/dto/ReportDTO.java
+++ b/src/main/java/com/yapp/project/report/domain/dto/ReportDTO.java
@@ -118,7 +118,7 @@ public class ReportDTO {
 
     @Getter
     public static class ResponseMonthReport {
-        @ApiModelProperty(value = "주차별 수행률", example = "[30, 40, 67, 48]")
+        @ApiModelProperty(value = "주차별 수행률", example = "[30, 40, 67, 48, 0]")
         List<Integer> weekRateList = new ArrayList<>();
         List<MonthResultByCategory> resultByCategory = new ArrayList<>();
 

--- a/src/main/java/com/yapp/project/report/service/ReportService.java
+++ b/src/main/java/com/yapp/project/report/service/ReportService.java
@@ -18,9 +18,13 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.text.DateFormat;
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
 import java.time.DayOfWeek;
 import java.time.LocalDate;
 import java.time.format.TextStyle;
+import java.time.temporal.TemporalAdjuster;
 import java.time.temporal.TemporalAdjusters;
 import java.util.*;
 import java.util.stream.Collectors;
@@ -34,6 +38,9 @@ public class ReportService {
     private final WeekReportRepository weekReportRepository;
     private final MonthRoutineReportRepository monthRoutineReportRepository;
 
+    private static final DateFormat dateFormatW = new SimpleDateFormat("w");
+    private static final DateFormat dateFormat = new SimpleDateFormat("yyyy-MM-dd");
+
     @Transactional
     public ReportDTO.ResponseWeekReportMessage getWeekReportLastDate(Account account, LocalDate date) {
         WeekReport weekReport = weekReportRepository.findByAccountAndLastDate(account, date).orElseThrow(WeekReportNotFoundMonthException::new);
@@ -41,15 +48,36 @@ public class ReportService {
     }
 
     @Transactional(readOnly = true)
-    public ReportDTO.ResponseMonthReportMessage getMonthReportByYearAndMonth(Account account, Integer year, Integer month) {
+    public ReportDTO.ResponseMonthReportMessage getMonthReportByYearAndMonth(Account account, Integer year, Integer month) throws ParseException {
         List<MonthRoutineReport> monthReportList = monthRoutineReportRepository.findAllByAccountAndYearAndMonth(account, year, month);
         List<WeekReport> weekReportList =
                 weekReportRepository.findAllByAccountAndMonthReportYearAndMonthReportMonthOrderByLastDate(account, year, month);
         if(monthReportList.isEmpty() && weekReportList.isEmpty()) {
             throw new MonthReportNotFoundMonthException();
         }
-        List<Integer> weekRateList = weekReportList.stream().map(WeekReport::getRate).collect(Collectors.toList());
+        LocalDate tempDate = LocalDate.of(year, month, 1);
+        List<Integer> weekRateList = List.of(getWeekRateList(weekReportList, tempDate));
         return ReportDTO.ResponseMonthReportMessage.of(monthReportList, weekRateList);
+    }
+
+    private Integer[] getWeekRateList(List<WeekReport> weekReportList, LocalDate tempDate) throws ParseException {
+        Integer[] weekRateList = new Integer[] {0, 0, 0, 0, 0};
+        Integer lastWeekNum = getLastWeekNum(tempDate);
+        weekReportList.forEach( weekReport -> {
+            int index = (weekReport.getWeekNum() - lastWeekNum) - 1;
+            if(index < 0) {
+                index = (( 52 +  weekReport.getWeekNum()) - lastWeekNum - 1);
+            }
+            weekRateList[index] = weekReport.getRate();
+        });
+        return weekRateList;
+    }
+
+    private Integer getLastWeekNum(LocalDate tempDate) throws ParseException {
+        TemporalAdjuster temporalAdjuster = TemporalAdjusters.dayOfWeekInMonth(1, DayOfWeek.WEDNESDAY);
+        LocalDate date = tempDate.with(temporalAdjuster);
+        String lastWeekStr = dateFormatW.format(dateFormat.parse(String.valueOf(date)));
+        return Integer.parseInt(lastWeekStr);
     }
 
     @Transactional
@@ -65,7 +93,7 @@ public class ReportService {
     }
 
     @Transactional
-    public WeekReport makeWeekReport(Account account) {
+    public WeekReport makeWeekReport(Account account) throws ParseException {
         checkIsReported(account);
         /** index 0 : notDone, 1 : fullyDone, 2 : particularlyDone */
         int[] result = new int[]{0, 0, 0};
@@ -179,14 +207,15 @@ public class ReportService {
                     .routineCreateAt(routine.getCreatedAt()).build()).collect(Collectors.toList());
     }
 
-    private void setRetrospectBasicData(Account account, int[] result, WeekReport weekReport) {
+    private void setRetrospectBasicData(Account account, int[] result, WeekReport weekReport) throws ParseException {
+        String weekNum = dateFormatW.format(dateFormat.parse(String.valueOf(DateUtil.KST_LOCAL_DATE_NOW())));
         weekReport.addBasicData(
                 account,
                 (int) (((result[1] + (result[2] * 0.5)) / (result[0] + (result[1] + result[2]))) * 100),
                 result[0],
                 result[1],
-                result[2]
+                result[2],
+                Integer.parseInt(weekNum)
         );
     }
-
 }

--- a/src/main/java/com/yapp/project/report/service/ReportService.java
+++ b/src/main/java/com/yapp/project/report/service/ReportService.java
@@ -40,6 +40,7 @@ public class ReportService {
 
     private static final DateFormat dateFormatW = new SimpleDateFormat("w");
     private static final DateFormat dateFormat = new SimpleDateFormat("yyyy-MM-dd");
+    private static final int YEAR_OF_WEEK = 52;
 
     @Transactional
     public ReportDTO.ResponseWeekReportMessage getWeekReportLastDate(Account account, LocalDate date) {
@@ -58,26 +59,6 @@ public class ReportService {
         LocalDate tempDate = LocalDate.of(year, month, 1);
         List<Integer> weekRateList = List.of(getWeekRateList(weekReportList, tempDate));
         return ReportDTO.ResponseMonthReportMessage.of(monthReportList, weekRateList);
-    }
-
-    private Integer[] getWeekRateList(List<WeekReport> weekReportList, LocalDate tempDate) throws ParseException {
-        Integer[] weekRateList = new Integer[] {0, 0, 0, 0, 0};
-        Integer lastWeekNum = getLastWeekNum(tempDate);
-        weekReportList.forEach( weekReport -> {
-            int index = (weekReport.getWeekNum() - lastWeekNum) - 1;
-            if(index < 0) {
-                index = (( 52 +  weekReport.getWeekNum()) - lastWeekNum - 1);
-            }
-            weekRateList[index] = weekReport.getRate();
-        });
-        return weekRateList;
-    }
-
-    private Integer getLastWeekNum(LocalDate tempDate) throws ParseException {
-        TemporalAdjuster temporalAdjuster = TemporalAdjusters.dayOfWeekInMonth(1, DayOfWeek.WEDNESDAY);
-        LocalDate date = tempDate.with(temporalAdjuster);
-        String lastWeekStr = dateFormatW.format(dateFormat.parse(String.valueOf(date)));
-        return Integer.parseInt(lastWeekStr);
     }
 
     @Transactional
@@ -217,5 +198,25 @@ public class ReportService {
                 result[2],
                 Integer.parseInt(weekNum)
         );
+    }
+
+    private Integer[] getWeekRateList(List<WeekReport> weekReportList, LocalDate tempDate) throws ParseException {
+        Integer[] weekRateList = new Integer[] {0, 0, 0, 0, 0};
+        Integer lastWeekNum = getLastWeekNum(tempDate);
+        weekReportList.forEach( weekReport -> {
+            int index = (weekReport.getWeekNum() - lastWeekNum) - 1;
+            if(index < 0) {
+                index = (( YEAR_OF_WEEK +  weekReport.getWeekNum()) - lastWeekNum - 1);
+            }
+            weekRateList[index] = weekReport.getRate();
+        });
+        return weekRateList;
+    }
+
+    private Integer getLastWeekNum(LocalDate tempDate) throws ParseException {
+        TemporalAdjuster temporalAdjuster = TemporalAdjusters.dayOfWeekInMonth(1, DayOfWeek.WEDNESDAY);
+        LocalDate date = tempDate.with(temporalAdjuster);
+        String lastWeekStr = dateFormatW.format(dateFormat.parse(String.valueOf(date)));
+        return Integer.parseInt(lastWeekStr);
     }
 }

--- a/src/test/java/com/yapp/project/report/MonthReportServiceTest.java
+++ b/src/test/java/com/yapp/project/report/MonthReportServiceTest.java
@@ -10,10 +10,16 @@ import com.yapp.project.report.domain.dto.ReportDTO;
 import com.yapp.project.report.service.ReportService;
 import com.yapp.project.report.template.MonthReportTemplate;
 import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.text.ParseException;
+import java.time.LocalDate;
 import java.util.List;
+
 import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
@@ -31,41 +37,50 @@ public class MonthReportServiceTest {
 
     @Test
     @Transactional
-    void testMonthReportSuccess() {
-        //given
-        Account account = AccountTemplate.makeTestAccount();
-        Account savedAccount = accountRepository.save(account);
-        WeekReport week1Report = MonthReportTemplate.makeWeek1(savedAccount);
-        WeekReport week2Report = MonthReportTemplate.makeWeek2(savedAccount);
-        WeekReport week3Report = MonthReportTemplate.makeWeek3(savedAccount);
-        WeekReport week4Report = MonthReportTemplate.makeWeek4(savedAccount);
-        weekReportRepository.save(week1Report);
-        weekReportRepository.save(week2Report);
-        weekReportRepository.save(week3Report);
-        weekReportRepository.save(week4Report);
-        int year = DateUtil.KST_LOCAL_DATE_NOW().getYear();
-        int month = DateUtil.KST_LOCAL_DATE_NOW().getMonth().getValue() - 1;
+    void testMonthReportSuccess(){
+        try(MockedStatic<DateUtil> dateUtil = Mockito.mockStatic(DateUtil.class)) {
+            //given
+            Account account = AccountTemplate.makeTestAccount();
+            Account savedAccount = accountRepository.save(account);
+            dateUtil.when(DateUtil::KST_LOCAL_DATE_NOW).thenReturn(LocalDate.parse("2021-10-06"));
+            WeekReport week1Report = MonthReportTemplate.makeWeek1(savedAccount);
+            dateUtil.when(DateUtil::KST_LOCAL_DATE_NOW).thenReturn(LocalDate.parse("2021-10-13"));
+            WeekReport week2Report = MonthReportTemplate.makeWeek2(savedAccount);
+            dateUtil.when(DateUtil::KST_LOCAL_DATE_NOW).thenReturn(LocalDate.parse("2021-10-20"));
+            WeekReport week3Report = MonthReportTemplate.makeWeek3(savedAccount);
+            dateUtil.when(DateUtil::KST_LOCAL_DATE_NOW).thenReturn(LocalDate.parse("2021-10-27"));
+            WeekReport week4Report = MonthReportTemplate.makeWeek4(savedAccount);
+            dateUtil.when(DateUtil::KST_LOCAL_DATE_NOW).thenReturn(LocalDate.parse("2021-11-03"));
+            weekReportRepository.save(week1Report);
+            weekReportRepository.save(week2Report);
+            weekReportRepository.save(week3Report);
+            weekReportRepository.save(week4Report);
+            int year = DateUtil.KST_LOCAL_DATE_NOW().getYear();
+            int month = DateUtil.KST_LOCAL_DATE_NOW().getMonth().getValue() - 1;
 
-        // when
-        reportService.makeMonthReport(savedAccount);
-        ReportDTO.ResponseMonthReportMessage monthReportByYearAndMonth = reportService.getMonthReportByYearAndMonth(savedAccount, year, month);
-        List<Integer> weekRateList = monthReportByYearAndMonth.getData().getWeekRateList();
-        List<ReportDTO.MonthResultByCategory> resultByCategory = monthReportByYearAndMonth.getData().getResultByCategory();
-        assertAll(
-                /* Check Week Rate */
-                () -> assertEquals(weekRateList.get(0), 45),
-                () -> assertEquals(weekRateList.get(1), 30),
-                () -> assertEquals(weekRateList.get(2), 42),
-                () -> assertEquals(weekRateList.get(3), 42),
-                /* Check Category Rate */
-                () -> assertEquals(resultByCategory.get(2).getRate(), 40),
-                () -> assertEquals(resultByCategory.get(3).getRate(), 60),
-                /* Check Routine Result(size) */
-                () -> assertEquals(resultByCategory.get(2).getRoutineReportList().get(0).getFullyDoneRate(), 44), // Running
-                () -> assertEquals(resultByCategory.get(2).getRoutineReportList().get(1).getFullyDoneRate(), 52), // Water
-                () -> assertEquals(resultByCategory.get(3).getRoutineReportList().get(0).getFullyDoneRate(), 50), // Coffee
-                () -> assertEquals(resultByCategory.get(3).getRoutineReportList().get(1).getFullyDoneRate(), 29), // Reading
-                () -> assertEquals(resultByCategory.get(3).getRoutineReportList().get(2).getFullyDoneRate(), 0) // Vitamin
-        );
+            // when
+            reportService.makeMonthReport(savedAccount);
+            ReportDTO.ResponseMonthReportMessage monthReportByYearAndMonth = reportService.getMonthReportByYearAndMonth(savedAccount, year, month);
+            List<Integer> weekRateList = monthReportByYearAndMonth.getData().getWeekRateList();
+            List<ReportDTO.MonthResultByCategory> resultByCategory = monthReportByYearAndMonth.getData().getResultByCategory();
+            assertAll(
+                    /* Check Week Rate */
+                    () -> assertEquals(weekRateList.get(0), 45),
+                    () -> assertEquals(weekRateList.get(1), 30),
+                    () -> assertEquals(weekRateList.get(2), 42),
+                    () -> assertEquals(weekRateList.get(3), 42),
+                    /* Check Category Rate */
+                    () -> assertEquals(resultByCategory.get(2).getRate(), 40),
+                    () -> assertEquals(resultByCategory.get(3).getRate(), 60),
+                    /* Check Routine Result(size) */
+                    () -> assertEquals(resultByCategory.get(2).getRoutineReportList().get(0).getFullyDoneRate(), 44), // Running
+                    () -> assertEquals(resultByCategory.get(2).getRoutineReportList().get(1).getFullyDoneRate(), 52), // Water
+                    () -> assertEquals(resultByCategory.get(3).getRoutineReportList().get(0).getFullyDoneRate(), 50), // Coffee
+                    () -> assertEquals(resultByCategory.get(3).getRoutineReportList().get(1).getFullyDoneRate(), 29), // Reading
+                    () -> assertEquals(resultByCategory.get(3).getRoutineReportList().get(2).getFullyDoneRate(), 0) // Vitamin
+            );
+        } catch (ParseException e) {
+            e.printStackTrace();
+        }
     }
 }

--- a/src/test/java/com/yapp/project/report/WeekReportServiceTest.java
+++ b/src/test/java/com/yapp/project/report/WeekReportServiceTest.java
@@ -18,6 +18,8 @@ import org.mockito.Mock;
 import org.mockito.MockedStatic;
 import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.text.ParseException;
 import java.time.LocalDate;
 import java.util.List;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -53,6 +55,8 @@ public class WeekReportServiceTest {
             WeekReport weekReport = reportService.makeWeekReport(account);
             // then
             assertThat(weekReport.getRate()).isEqualTo(62);
+        } catch (ParseException e) {
+            e.printStackTrace();
         }
     }
 
@@ -72,6 +76,8 @@ public class WeekReportServiceTest {
             WeekReport weekReport = reportService.makeWeekReport(account);
             // then
             assertThat(weekReport.getRate()).isEqualTo(66);
+        } catch (ParseException e) {
+            e.printStackTrace();
         }
     }
 
@@ -91,6 +97,8 @@ public class WeekReportServiceTest {
             WeekReport weekReport = reportService.makeWeekReport(account);
             // then
             assertThat(weekReport.getRate()).isEqualTo(69);
+        } catch (ParseException e) {
+            e.printStackTrace();
         }
     }
 
@@ -110,6 +118,8 @@ public class WeekReportServiceTest {
             WeekReport weekReport = reportService.makeWeekReport(account);
             // then
             assertThat(weekReport.getRate()).isEqualTo(63);
+        } catch (ParseException e) {
+            e.printStackTrace();
         }
     }
 }

--- a/src/test/java/com/yapp/project/report/template/MonthReportTemplate.java
+++ b/src/test/java/com/yapp/project/report/template/MonthReportTemplate.java
@@ -14,7 +14,7 @@ public class MonthReportTemplate {
     public static WeekReport makeWeek1(Account account){
         WeekReport week1 = WeekReport.builder().build();
         week1.addIdAndLastDate(id++, "2021-10-10");
-        week1.addBasicData(account, 45, 5, 2, 13);
+        week1.addBasicData(account, 45, 5, 2, 13, 42);
         RoutineResult readBook = RoutineResult.builder().category(RoutineCategory.DAILY).routineId(4L).title("독서").build();
         readBook.addWeekReport(week1); readBook.addRoutineResultDoneCount(new int[]{1, 0});
         readBook.addRoutineNotDoneCount(0);
@@ -40,7 +40,7 @@ public class MonthReportTemplate {
     public static WeekReport makeWeek2(Account account){
         WeekReport week2 = WeekReport.builder().build();
         week2.addIdAndLastDate(id++, "2021-10-17");
-        week2.addBasicData(account, 30, 8, 2, 10);
+        week2.addBasicData(account, 30, 8, 2, 10, 43);
         RoutineResult readBook = RoutineResult.builder().category(RoutineCategory.DAILY).routineId(4L).title("독서").build();
         readBook.addWeekReport(week2); readBook.addRoutineResultDoneCount(new int[]{1, 0});
         readBook.addRoutineNotDoneCount(1);
@@ -66,7 +66,7 @@ public class MonthReportTemplate {
     public static WeekReport makeWeek3(Account account){
         WeekReport week3 = WeekReport.builder().build();
         week3.addIdAndLastDate(id++, "2021-10-24");
-        week3.addBasicData(account, 42, 7, 3, 10);
+        week3.addBasicData(account, 42, 7, 3, 10, 44);
         RoutineResult readBook = RoutineResult.builder().category(RoutineCategory.DAILY).routineId(4L).title("독서").build();
         readBook.addWeekReport(week3); readBook.addRoutineResultDoneCount(new int[]{0, 1});
         readBook.addRoutineNotDoneCount(1);
@@ -92,7 +92,7 @@ public class MonthReportTemplate {
     public static WeekReport makeWeek4(Account account){
         WeekReport week4 = WeekReport.builder().build();
         week4.addIdAndLastDate(id++, "2021-10-31");
-        week4.addBasicData(account, 42, 7, 3, 10);
+        week4.addBasicData(account, 42, 7, 3, 10, 45);
         RoutineResult readBook = RoutineResult.builder().category(RoutineCategory.DAILY).routineId(4L).title("독서").build();
         readBook.addWeekReport(week4); readBook.addRoutineResultDoneCount(new int[]{0, 1});
         readBook.addRoutineNotDoneCount(1);


### PR DESCRIPTION
## 예외 케이스 설명 및 처리 결과
만약, 2021-12-21(화)에 가입하여 루틴을 시작한 경우라면 12월 주 리포트는 12-29에 발급, 01-05에 발급 총 2개만 존재합니다.
참고로 12월의 첫 주를 1주차로 계산하는 것이 아닌, 매주 첫 수요일 주가 1주차로 계산됩니다.
기존 로직이라면 2021-12월 리포트 조회 시 **weekRateList**가 다음과 같이 응답될 것 입니다.
```json
[
  30(12-29 발급 분),
  43(01-05 발급 분)
] 
```
하지만 이렇게 응답이 가면 12-29일 결과가 1주차로 맵핑됩니다.
수정 된 응답은 리스트의 크기를 5로 고정하고 해당 주차수에 맞게 응답합니다.
```json
[
  0,
  0,
  0,
  30(12-29),
  40(01-05)
]
```
## 추가된 로직 설명
정말 답이 없다 생각했지만.. 날짜 관련 클래스 찾아 보다가 년도의 주차수를 구하는 방법을 찾았습니다!
주차수로 해결할 수 있지 않을까..? 머리를 요리조리 굴려보다가 네 찾았습니다!!

우선, 주 리포트를 발급할 때 해당 주차수(년도)를 같이 저장합니다.
주차수 계산을 위해 WeekReport에 weekNum이라는 주차수 속성이 추가되었습니다.
추후 월 리포트를 조회할 때 사용됩니다.

1. 조회를 원하는 년, 월의 첫 번째 수요일의 주차수를 구합니다.
2. 해당 월로 등록된 주 리포트를 모두 가져온 후, 1번에서 구한 주차수와 계산을 합니다.
3. 2번을 통해 인덱스를 얻고 미리 정의해놓은 크기 5의 배열에 얻은 인덱스로 저장합니다.

추가적으로 12월에서 1월의 경우 년도가 넘어가면서 주차수 계산에 또 다른 예외가 발생합니다.
위 문제는 일반적인 1년 주차수인 52를 더한 후 계산을 진행하여 대응합니다.
(-1 연산은 계산 값을 index로 맵핑하기 위한 연산임돵)

실제 코드는 다음과 같습니다.
```java
  private Integer[] getWeekRateList(List<WeekReport> weekReportList, LocalDate tempDate) throws ParseException {
        Integer[] weekRateList = new Integer[] {0, 0, 0, 0, 0};
        Integer lastWeekNum = getLastWeekNum(tempDate);
        weekReportList.forEach( weekReport -> {
            int index = (weekReport.getWeekNum() - lastWeekNum) - 1;
            if(index < 0) {
                index = (( 52 +  weekReport.getWeekNum()) - lastWeekNum - 1);
            }
            weekRateList[index] = weekReport.getRate();
        });
        return weekRateList;
    }

    private Integer getLastWeekNum(LocalDate tempDate) throws ParseException {
        TemporalAdjuster temporalAdjuster = TemporalAdjusters.dayOfWeekInMonth(1, DayOfWeek.WEDNESDAY);
        LocalDate date = tempDate.with(temporalAdjuster);
        String lastWeekStr = dateFormatW.format(dateFormat.parse(String.valueOf(date)));
        return Integer.parseInt(lastWeekStr);
    }
```
## 끝

리포트 정말 너무 힘드네요.. 너~~~무 힘들어요 ㅠㅠ
저희 서비스는 1주차가 일반적인 월 1주차가 아니라 매 월 첫번째 수요일 기준이라 일반적인 날짜 클래스로 간단하게 해결이 안되다 보니.. 우오ㅔ어ㅏ엑😵
그리고.. 리포트는 기본적으로 발급 기간이 길다보니 테스트케이스로 완벽하게 체킹하기도 어려워서 계속 여러 경우 생각해보면서 체킹하고 있기는 하지만.. 혹여나 또 다른 예외가 있을까 겁도 나네요 으아으어아억😵‍💫

---
[참고한 날짜 관련 메서드 정리](https://velog.io/@jaca/%EB%82%A0%EC%A7%9C%EC%99%80-%EC%8B%9C%EA%B0%84-%ED%98%95%EC%8B%9D%ED%99%94)
