### PR TITLE
[YAPPIOS-238] JPA를 쓸 때 기본적으로 LAZY 전략으로 무조건 써야한다고 해서 바꿈

### DIFF
--- a/src/main/java/com/yapp/project/account/domain/Account.java
+++ b/src/main/java/com/yapp/project/account/domain/Account.java
@@ -74,8 +74,8 @@ public class Account {
     @ToString.Exclude
     private final List<Notification> notificationLists = new ArrayList<>();
 
-    public void setIdForTest(Long id) {
-        this.id = id;
+    public void setIsAlarm(Boolean isOn){
+        this.isAlarm = isOn;
     }
 
     public void updateLastLoginAccount(){
@@ -94,8 +94,9 @@ public class Account {
         this.password = passwordEncoder.encode(newPassword);
     }
 
-    public void setIsAlarm(Boolean isOn){
-        this.isAlarm = isOn;
+
+    public void setIdForTest(Long id) {
+        this.id = id;
     }
 
 }

--- a/src/main/java/com/yapp/project/account/domain/Account.java
+++ b/src/main/java/com/yapp/project/account/domain/Account.java
@@ -58,8 +58,8 @@ public class Account {
 
     @PrePersist
     public void prePersist() {
-        this.isDelete= isDelete != null && isDelete;
-        this.isAlarm= isAlarm != null && isAlarm;
+        this.isDelete= false;
+        this.isAlarm= false;
     }
 
     @OneToMany(mappedBy = "account", cascade = CascadeType.ALL, fetch = FetchType.LAZY)
@@ -93,7 +93,6 @@ public class Account {
     public void resetPassword(PasswordEncoder passwordEncoder, String newPassword){
         this.password = passwordEncoder.encode(newPassword);
     }
-
 
     public void setIdForTest(Long id) {
         this.id = id;

--- a/src/main/java/com/yapp/project/capture/domain/Capture.java
+++ b/src/main/java/com/yapp/project/capture/domain/Capture.java
@@ -58,11 +58,6 @@ public class Capture {
 
     private LocalDateTime createdAt;
 
-    public CaptureDto.CaptureResponse toCaptureResponse(){
-        return CaptureDto.CaptureResponse.builder().images(captureImage).captureId(id)
-                .build();
-    }
-
     public void updateCaptureImage(CaptureImage images){
         captureImage.add(images);
     }
@@ -70,4 +65,10 @@ public class Capture {
     public void remove(){
         this.isDelete=true;
     }
+
+    public CaptureDto.CaptureResponse toCaptureResponse(){
+        return CaptureDto.CaptureResponse.builder().images(captureImage).captureId(id)
+                .build();
+    }
+
 }

--- a/src/main/java/com/yapp/project/capture/domain/Capture.java
+++ b/src/main/java/com/yapp/project/capture/domain/Capture.java
@@ -18,23 +18,6 @@ import static com.yapp.project.aux.common.DateUtil.KST_LOCAL_DATETIME_NOW;
 @Entity
 @NoArgsConstructor
 public class Capture {
-
-    @Builder
-    public Capture(Long id, Mission mission, Organization organization, Integer rank, Achievement achievement){
-        this.id = id;
-        this.organization = organization;
-        this.mission = mission;
-        this.rank = rank;
-        this.myAchievementRate = achievement.getMyAchievementRate();
-        this.groupAchievementRate = achievement.getGroupAchievementRate();
-        this.createdAt = KST_LOCAL_DATETIME_NOW();
-    }
-
-    @PrePersist
-    public void prePersist(){
-        this.isDelete= isDelete != null && isDelete;
-    }
-
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
@@ -57,6 +40,23 @@ public class Capture {
     private Boolean isDelete;
 
     private LocalDateTime createdAt;
+
+
+    @Builder
+    public Capture(Long id, Mission mission, Organization organization, Integer rank, Achievement achievement){
+        this.id = id;
+        this.organization = organization;
+        this.mission = mission;
+        this.rank = rank;
+        this.myAchievementRate = achievement.getMyAchievementRate();
+        this.groupAchievementRate = achievement.getGroupAchievementRate();
+        this.createdAt = KST_LOCAL_DATETIME_NOW();
+    }
+
+    @PrePersist
+    public void prePersist(){
+        this.isDelete= false;
+    }
 
     public void updateCaptureImage(CaptureImage images){
         captureImage.add(images);

--- a/src/main/java/com/yapp/project/mission/domain/Mission.java
+++ b/src/main/java/com/yapp/project/mission/domain/Mission.java
@@ -52,7 +52,7 @@ public class Mission {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @ManyToOne(targetEntity = Organization.class,fetch = FetchType.EAGER)
+    @ManyToOne(targetEntity = Organization.class,fetch = FetchType.LAZY)
     private Organization organization;
 
     @ManyToOne(targetEntity = Account.class, fetch = FetchType.LAZY)
@@ -96,10 +96,6 @@ public class Mission {
         return (this.successCount/(this.failureCount+this.successCount))*100;
     }
 
-    public void setIdForTest(Long id) {
-        this.id = id;
-    }
-
     public void clickAlarmToggle(){
         this.isAlarm=!this.isAlarm;
     }
@@ -130,23 +126,6 @@ public class Mission {
         this.isFinish=true;
     }
 
-    public void defaultSettingForTest(){
-        this.successCount = 0;
-        this.failureCount = 0;
-        this.isFinish = false;
-        this.isDelete = false;
-        this.isAlarm = false;
-    }
-
-    public void setWeeksForTest(List<Cron> weeks){
-        this.weeks.addAll(weeks);
-    }
-
-    public void setCountForTest(){
-        this.successCount = Utils.randomNumber();
-        this.failureCount = Utils.randomNumber();
-    }
-
     public MissionDto.MissionResponse toMissionResponse(){
         return MissionDto.MissionResponse.builder().image(organization.getImage()).title(organization.getTitle())
                 .achievementRate(this.getAchievementRate()).period(this.getPeriod()).category(organization.getCategory().getIndex())
@@ -169,4 +148,26 @@ public class Mission {
                 .nowPeople(this.organization.getCount())
                 .build();
     }
+
+    public void setIdForTest(Long id) {
+        this.id = id;
+    }
+
+    public void defaultSettingForTest(){
+        this.successCount = 0;
+        this.failureCount = 0;
+        this.isFinish = false;
+        this.isDelete = false;
+        this.isAlarm = false;
+    }
+
+    public void setWeeksForTest(List<Cron> weeks){
+        this.weeks.addAll(weeks);
+    }
+
+    public void setCountForTest(){
+        this.successCount = Utils.randomNumber();
+        this.failureCount = Utils.randomNumber();
+    }
+
 }

--- a/src/main/java/com/yapp/project/mission/domain/Mission.java
+++ b/src/main/java/com/yapp/project/mission/domain/Mission.java
@@ -23,31 +23,6 @@ import java.util.stream.Collectors;
 @NoArgsConstructor
 @ToString
 public class Mission {
-
-    @Builder
-    public Mission(
-            Organization organization, Account account, LocalDate startDate, LocalDate finishDate,
-            Boolean isFinish, Boolean isAlarm, LocalTime startTime
-    ){
-        this.organization = organization;
-        this.account = account;
-        this.startDate = startDate;
-        this.finishDate = finishDate;
-        this.isFinish = isFinish;
-        this.isAlarm = isAlarm;
-        this.startTime = startTime;
-    }
-
-    @PrePersist
-    public void prePersist(){
-        this.isFinish = (this.isFinish!=null)&&this.isFinish;
-        this.isDelete = (this.isDelete!=null)&&this.isDelete;
-        this.isAlarm = (this.isAlarm!=null)&&this.isAlarm;
-        this.successCount = this.successCount!=null?this.successCount:0;
-        this.failureCount = this.failureCount!=null?this.failureCount:0;
-    }
-
-
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
@@ -78,6 +53,29 @@ public class Mission {
     private Boolean isFinish;
 
     private Boolean isDelete;
+
+    @Builder
+    public Mission(
+            Organization organization, Account account, LocalDate startDate, LocalDate finishDate,
+            Boolean isFinish, Boolean isAlarm, LocalTime startTime
+    ){
+        this.organization = organization;
+        this.account = account;
+        this.startDate = startDate;
+        this.finishDate = finishDate;
+        this.isFinish = isFinish;
+        this.isAlarm = isAlarm;
+        this.startTime = startTime;
+    }
+
+    @PrePersist
+    public void prePersist(){
+        this.isFinish = (this.isFinish!=null)&&this.isFinish;
+        this.isDelete = (this.isDelete!=null)&&this.isDelete;
+        this.isAlarm = (this.isAlarm!=null)&&this.isAlarm;
+        this.successCount = this.successCount!=null?this.successCount:0;
+        this.failureCount = this.failureCount!=null?this.failureCount:0;
+    }
 
     public void addDays(List<Cron> days){
         this.weeks.addAll(days);

--- a/src/main/java/com/yapp/project/notice/domain/Notice.java
+++ b/src/main/java/com/yapp/project/notice/domain/Notice.java
@@ -31,7 +31,7 @@ public class Notice {
 
     @PrePersist
     public void prePersist() {
-        this.createdAt = DateUtil.KST_LOCAL_DATE_NOW(); //this.createdAt!=null?this.createdAt:
+        this.createdAt = DateUtil.KST_LOCAL_DATE_NOW();
     }
 
     public void setContentForTest(String content) {

--- a/src/main/java/com/yapp/project/notification/domain/Notification.java
+++ b/src/main/java/com/yapp/project/notification/domain/Notification.java
@@ -18,7 +18,7 @@ public class Notification {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     private Account account;
 
     private String title;

--- a/src/main/java/com/yapp/project/organization/domain/Organization.java
+++ b/src/main/java/com/yapp/project/organization/domain/Organization.java
@@ -18,29 +18,6 @@ import java.util.List;
 @AllArgsConstructor
 public class Organization {
 
-    @Builder
-    public Organization(String title , Integer rate, Category category, Clause clause){
-        this.title = title;
-        this.rate = rate;
-        this.category = category;
-        this.shoot = clause.getShoot();
-        this.beginTime = clause.getBeginTime();
-        this.endTime = clause.getEndTime();
-        this.description = clause.getDescription();
-        this.recommend = clause.getRecommend();
-        this.updatedAt = DateUtil.KST_LOCAL_DATE_NOW();
-
-    }
-
-    @PrePersist
-    public void prePersist(){
-        this.count = this.count == null ? 0 : this.count;
-        this.groupSuccessCount = this.groupSuccessCount == null ? 0 : this.groupSuccessCount;
-        this.groupFailCount = this.groupFailCount == null ? 0 : this.groupFailCount;
-        this.participants = this.participants==null ? 0 : this.participants;
-    }
-
-
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
@@ -80,6 +57,28 @@ public class Organization {
     @Column(columnDefinition="TEXT")
     private String recommend;
 
+    @Builder
+    public Organization(String title , Integer rate, Category category, Clause clause){
+        this.title = title;
+        this.rate = rate;
+        this.category = category;
+        this.shoot = clause.getShoot();
+        this.beginTime = clause.getBeginTime();
+        this.endTime = clause.getEndTime();
+        this.description = clause.getDescription();
+        this.recommend = clause.getRecommend();
+        this.updatedAt = DateUtil.KST_LOCAL_DATE_NOW();
+
+    }
+
+    @PrePersist
+    public void prePersist(){
+        this.count = 0;
+        this.groupSuccessCount = 0;
+        this.groupFailCount = 0;
+        this.participants = 0;
+    }
+
     public void updateParticipants(Integer participants) {
         this.participants = participants;
     }
@@ -87,11 +86,6 @@ public class Organization {
     public void updateCurrentCount(){
         this.count = count==null? 0: count;
         this.count+=1;
-    }
-
-    public void defaultSettingForTest(){
-        this.count = 0;
-        this.rate = 0;
     }
 
     public Integer getCount(){
@@ -133,12 +127,17 @@ public class Organization {
     public OrgDto.OrgDetailResponse toDetailResponseDto(){
         return OrgDto.OrgDetailResponse.builder().id(id)
                 .shoot(shoot).participant(participants).rate(rate).title(title)
-                .category(category.getIndex()).beginTime(beginTime).endTime(endTime).description(description).recommend(recommend).build();
+                .category(category.getIndex()).beginTime(beginTime).endTime(endTime)
+                .description(description).recommend(recommend).build();
     }
 
     public void setIdForTest(Long id) {
         this.id = id;
     }
 
+    public void defaultSettingForTest(){
+        this.count = 0;
+        this.rate = 0;
+    }
 
 }

--- a/src/main/java/com/yapp/project/report/domain/MonthRoutineReport.java
+++ b/src/main/java/com/yapp/project/report/domain/MonthRoutineReport.java
@@ -2,7 +2,6 @@ package com.yapp.project.report.domain;
 
 import com.yapp.project.account.domain.Account;
 import com.yapp.project.aux.common.DateUtil;
-import com.yapp.project.organization.domain.Category;
 import com.yapp.project.routine.domain.RoutineCategory;
 import lombok.Builder;
 import lombok.Getter;
@@ -19,7 +18,7 @@ public class MonthRoutineReport {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     private Account account;
 
     private String title;

--- a/src/main/java/com/yapp/project/report/domain/RetrospectReportDay.java
+++ b/src/main/java/com/yapp/project/report/domain/RetrospectReportDay.java
@@ -16,7 +16,7 @@ public class RetrospectReportDay {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     private RoutineResult routineResult;
 
     private String day;

--- a/src/main/java/com/yapp/project/report/domain/RoutineResult.java
+++ b/src/main/java/com/yapp/project/report/domain/RoutineResult.java
@@ -1,10 +1,10 @@
 package com.yapp.project.report.domain;
 
-import com.yapp.project.organization.domain.Category;
 import com.yapp.project.routine.domain.RoutineCategory;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+
 import javax.persistence.*;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
@@ -19,7 +19,7 @@ public class RoutineResult{
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     private WeekReport weekReport;
 
     @OneToMany(mappedBy = "routineResult", cascade = CascadeType.ALL)

--- a/src/main/java/com/yapp/project/retrospect/domain/Retrospect.java
+++ b/src/main/java/com/yapp/project/retrospect/domain/Retrospect.java
@@ -6,12 +6,12 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+
 import javax.persistence.*;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 
 import static com.yapp.project.aux.common.DateUtil.KST_LOCAL_DATETIME_NOW;
-import static com.yapp.project.aux.common.DateUtil.KST_LOCAL_DATE_NOW;
 
 @Entity
 @Getter
@@ -23,11 +23,11 @@ public class Retrospect {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "routine_id")
     private Routine routine;
 
-    @OneToOne(cascade = CascadeType.ALL, orphanRemoval = true)
+    @OneToOne(fetch = FetchType.LAZY, cascade = CascadeType.ALL, orphanRemoval = true)
     @JoinColumn(name = "image_id")
     private Snapshot image;
 

--- a/src/main/java/com/yapp/project/routine/domain/RoutineDay.java
+++ b/src/main/java/com/yapp/project/routine/domain/RoutineDay.java
@@ -25,7 +25,7 @@ public class RoutineDay {
 
     private Long sequence;
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "routine_id")
     private Routine routine;
 

--- a/src/main/java/com/yapp/project/saying/domain/Saying.java
+++ b/src/main/java/com/yapp/project/saying/domain/Saying.java
@@ -13,6 +13,14 @@ import javax.persistence.*;
 @NoArgsConstructor
 @ToString
 public class Saying {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String content;
+
+    @Column(columnDefinition = "VARCHAR(255) default '작자미상'")
+    private String author;
 
     @Builder
     public Saying(Long id, String content, String author){
@@ -24,15 +32,7 @@ public class Saying {
 
     @PrePersist
     public void prePersist(){
-        this.author = this.author == null ? "작자미상" : this.author;
+        this.author = "작자미상";
     }
 
-    @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Long id;
-
-    private String content;
-
-    @Column(columnDefinition = "VARCHAR(255) default '작자미상'")
-    private String author;
 }

--- a/src/main/java/com/yapp/project/saying/domain/SayingRecord.java
+++ b/src/main/java/com/yapp/project/saying/domain/SayingRecord.java
@@ -14,14 +14,6 @@ import static com.yapp.project.aux.common.DateUtil.KST_LOCAL_DATETIME_NOW;
 @Entity
 @NoArgsConstructor
 public class SayingRecord {
-
-    @Builder
-    public SayingRecord(Account account, Saying saying){
-        this.account = account;
-        this.saying = saying;
-        this.createdAt = KST_LOCAL_DATETIME_NOW();
-    }
-
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
@@ -33,4 +25,13 @@ public class SayingRecord {
     private Saying saying;
 
     private LocalDateTime createdAt;
+
+
+    @Builder
+    public SayingRecord(Account account, Saying saying){
+        this.account = account;
+        this.saying = saying;
+        this.createdAt = KST_LOCAL_DATETIME_NOW();
+    }
+
 }

--- a/src/main/java/com/yapp/project/snapshot/domain/Snapshot.java
+++ b/src/main/java/com/yapp/project/snapshot/domain/Snapshot.java
@@ -17,7 +17,7 @@ public class Snapshot {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @OneToOne(mappedBy = "image")
+    @OneToOne(mappedBy = "image", fetch = FetchType.LAZY)
     @JoinColumn(name = "retrospect_id")
     private Retrospect retrospect;
 

--- a/src/main/java/com/yapp/project/snapshot/domain/Snapshot.java
+++ b/src/main/java/com/yapp/project/snapshot/domain/Snapshot.java
@@ -17,7 +17,7 @@ public class Snapshot {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @OneToOne(mappedBy = "image", fetch = FetchType.LAZY)
+    @OneToOne(mappedBy = "image")
     @JoinColumn(name = "retrospect_id")
     private Retrospect retrospect;
 


### PR DESCRIPTION
- 코드 위치 조정
- 기본 전략을 lazy로 바꿈 왜냐하면 기본적으로 eager로 했을 때 쿼리가 한 번에 왔을 때의 위험이 있으므로 안전하게 lazy로 전환
- eager로 했을 때 그 테이블의 연관된 곳에서도 만약에 eager 전략을 썼을 때 예상하지 못한 쿼리들이 날아올 수 있음