### PR TITLE
[YAPPIOS-243] 회고 삭제 시 루틴 수행 여부 보존하도록 수정

### DIFF
--- a/src/main/java/com/yapp/project/aux/content/ReportContent.java
+++ b/src/main/java/com/yapp/project/aux/content/ReportContent.java
@@ -8,7 +8,7 @@ public class ReportContent {
     public static final String MONTH_REPORT_OK = "월 리포트를 성공적으로 조회하였습니다.";
     public static final String START_DATE_IS_NOT_MON = "요청하신 요일이 월요일이 아닙니다.";
     public static final String WEEK_REPORT_OK = "주 리포트를 성공적으로 조회하였습니다";
-    public static final String WEEK_REPORT_NOT_FOUND = "요청하신 요일이 일요일이 맞는지 확인하세요.";
+    public static final String WEEK_REPORT_NOT_FOUND = "리포트를 찾을 수 없습니다.";
     public static final String WEEK_REPORT_PUSH_START = ":arrow_forward:주 리포트 알림 푸시 시작합니다.";
     public static final String WEEK_REPORT_PUSH_END = ":ballot_box_with_check:주 리포트 알림 푸시 마쳤습니다.";
     public static final String MONTH_REPORT_PUSH_START = ":arrow_forward:월 리포트 알림 푸시 시작합니다.";

--- a/src/main/java/com/yapp/project/retrospect/domain/Retrospect.java
+++ b/src/main/java/com/yapp/project/retrospect/domain/Retrospect.java
@@ -83,6 +83,11 @@ public class Retrospect {
         this.isReport = false;
     }
 
+    public void deleteRetrospect() {
+        this.image = null;
+        this.content = null;
+    }
+
     /** Test */
     public void updateTestData(Long id, LocalDate date) {
         this.id = id;

--- a/src/main/java/com/yapp/project/retrospect/service/RetrospectService.java
+++ b/src/main/java/com/yapp/project/retrospect/service/RetrospectService.java
@@ -77,7 +77,8 @@ public class RetrospectService {
     public Message deleteRetrospect(Long retrospectId, Account account) {
         Retrospect retrospect = retrospectRepository.findById(retrospectId).orElseThrow(NotFoundRetrospectException::new);
         routineService.checkIsMine(account, retrospect.getRoutine());
-        retrospectRepository.delete(retrospect);
+        retrospect.deleteRetrospect();
+        retrospectRepository.save(retrospect);
         return Message.builder().msg(RETROSPECT_DELETE_BY_OK).status(StatusEnum.RETROSPECT_OK).build();
     }
 


### PR DESCRIPTION
회고 삭제 시 루틴 수행 여부 보존하도록 수정

- 루틴 수행여부 설정 후 회고를 작성한 뒤 다시 회고를 삭제한다면 기존 루틴 수행여부는 남기도록 수정